### PR TITLE
FI-2768: Client Allow Multiple Requests Per Hook

### DIFF
--- a/lib/davinci_crd_test_kit/client_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/client_hooks_group.rb
@@ -76,19 +76,19 @@ module DaVinciCRDTestKit
 
       test from: :crd_decode_auth_token,
            config: {
-             requests: {
-               hook_request: { name: :appointment_book }
+             options: {
+               hook_name: 'appointment-book'
              },
              outputs: {
-               auth_token: { name: :appointment_book_auth_token },
-               auth_token_payload_json: { name: :appointment_book_auth_token_payload_json },
-               auth_token_header_json: { name: :appointment_book_auth_token_header_json }
+               auth_tokens: { name: :appointment_book_auth_tokens },
+               auth_token_payloads_json: { name: :appointment_book_auth_token_payloads_json },
+               auth_tokens_header_json: { name: :appointment_book_auth_tokens_header_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_token_header_json: { name: :appointment_book_auth_token_header_json }
+               auth_tokens_header_json: { name: :appointment_book_auth_tokens_header_json }
              },
              outputs: {
                crd_jwks_json: { name: :appointment_book_crd_jwks_json },
@@ -98,40 +98,36 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_token_header_json: { name: :appointment_book_auth_token_header_json },
+               auth_tokens_header_json: { name: :appointment_book_auth_tokens_header_json },
                crd_jwks_keys_json: { name: :appointment_book_crd_jwks_keys_json }
              },
              outputs: {
-               auth_token_jwk_json: { name: :appointment_book_auth_token_jwk_json }
+               auth_tokens_jwk_json: { name: :appointment_book_auth_tokens_jwk_json }
              }
            }
       test from: :crd_token_payload,
            config: {
              options: { hook_path: APPOINTMENT_BOOK_PATH },
              inputs: {
-               auth_token: { name: :appointment_book_auth_token },
-               auth_token_jwk_json: { name: :appointment_book_auth_token_jwk_json }
+               auth_tokens: { name: :appointment_book_auth_tokens },
+               auth_tokens_jwk_json: { name: :appointment_book_auth_tokens_jwk_json }
              }
            }
 
       test from: :crd_hook_request_required_fields,
            config: {
              options: {
-               hook_path: APPOINTMENT_BOOK_PATH,
                hook_name: 'appointment-book'
-             },
-             requests: {
-               hook_request: { name: :appointment_book }
              }
            }
       test from: :crd_hook_request_optional_fields,
            config: {
+             options: {
+               hook_name: 'appointment-book'
+             },
              outputs: {
                client_fhir_server: { name: :appointment_book_client_fhir_server },
                client_access_token: { name: :appointment_book_client_access_token }
-             },
-             requests: {
-               hook_request: { name: :appointment_book }
              }
            }
 
@@ -141,18 +137,12 @@ module DaVinciCRDTestKit
                client_fhir_server: { name: :appointment_book_client_fhir_server },
                client_access_token: { name: :appointment_book_client_access_token }
              },
-             options: { hook_name: 'appointment-book' },
-             requests: {
-               hook_request: { name: :appointment_book }
-             }
+             options: { hook_name: 'appointment-book' }
            }
 
       test from: :crd_hook_request_valid_prefetch,
            config: {
-             options: { hook_name: 'appointment-book' },
-             requests: {
-               hook_request: { name: :appointment_book }
-             }
+             options: { hook_name: 'appointment-book' }
            }
 
       test from: :crd_card_display_attest_test,
@@ -183,19 +173,19 @@ module DaVinciCRDTestKit
 
       test from: :crd_decode_auth_token,
            config: {
-             requests: {
-               hook_request: { name: :encounter_start }
+             options: {
+               hook_name: 'encounter-discharge'
              },
              outputs: {
-               auth_token: { name: :encounter_start_auth_token },
-               auth_token_payload_json: { name: :encounter_start_auth_token_payload_json },
-               auth_token_header_json: { name: :encounter_start_auth_token_header_json }
+               auth_tokens: { name: :encounter_start_auth_tokens },
+               auth_token_payloads_json: { name: :encounter_start_auth_token_payloads_json },
+               auth_tokens_header_json: { name: :encounter_start_auth_tokens_header_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_token_header_json: { name: :encounter_start_auth_token_header_json }
+               auth_tokens_header_json: { name: :encounter_start_auth_tokens_header_json }
              },
              outputs: {
                crd_jwks_json: { name: :encounter_start_crd_jwks_json },
@@ -205,40 +195,36 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_token_header_json: { name: :encounter_start_auth_token_header_json },
+               auth_tokens_header_json: { name: :encounter_start_auth_tokens_header_json },
                crd_jwks_keys_json: { name: :encounter_start_crd_jwks_keys_json }
              },
              outputs: {
-               auth_token_jwk_json: { name: :encounter_start_auth_token_jwk_json }
+               auth_tokens_jwk_json: { name: :encounter_start_auth_tokens_jwk_json }
              }
            }
       test from: :crd_token_payload,
            config: {
              options: { hook_path: ENCOUNTER_START_PATH },
              inputs: {
-               auth_token: { name: :encounter_start_auth_token },
-               auth_token_jwk_json: { name: :encounter_start_auth_token_jwk_json }
+               auth_tokens: { name: :encounter_start_auth_tokens },
+               auth_tokens_jwk_json: { name: :encounter_start_auth_tokens_jwk_json }
              }
            }
 
       test from: :crd_hook_request_required_fields,
            config: {
              options: {
-               hook_path: ENCOUNTER_START_PATH,
                hook_name: 'encounter-start'
-             },
-             requests: {
-               hook_request: { name: :encounter_start }
              }
            }
       test from: :crd_hook_request_optional_fields,
            config: {
+             options: {
+               hook_name: 'encounter-start'
+             },
              outputs: {
                client_fhir_server: { name: :encounter_start_client_fhir_server },
                client_access_token: { name: :encounter_start_client_access_token }
-             },
-             requests: {
-               hook_request: { name: :encounter_start }
              }
            }
 
@@ -248,18 +234,12 @@ module DaVinciCRDTestKit
                client_fhir_server: { name: :encounter_start_client_fhir_server },
                client_access_token: { name: :encounter_start_client_access_token }
              },
-             options: { hook_name: 'encounter-start' },
-             requests: {
-               hook_request: { name: :encounter_start }
-             }
+             options: { hook_name: 'encounter-start' }
            }
 
       test from: :crd_hook_request_valid_prefetch,
            config: {
-             options: { hook_name: 'encounter-start' },
-             requests: {
-               hook_request: { name: :encounter_start }
-             }
+             options: { hook_name: 'encounter-discharge' }
            }
 
       test from: :crd_card_display_attest_test,
@@ -291,19 +271,19 @@ module DaVinciCRDTestKit
 
       test from: :crd_decode_auth_token,
            config: {
-             requests: {
-               hook_request: { name: :encounter_discharge }
+             options: {
+               hook_name: 'encounter-discharge'
              },
              outputs: {
-               auth_token: { name: :encounter_discharge_auth_token },
-               auth_token_payload_json: { name: :encounter_discharge_auth_token_payload_json },
-               auth_token_header_json: { name: :encounter_discharge_auth_token_header_json }
+               auth_tokens: { name: :encounter_discharge_auth_tokens },
+               auth_token_payloads_json: { name: :encounter_discharge_auth_token_payloads_json },
+               auth_tokens_header_json: { name: :encounter_discharge_auth_tokens_header_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_token_header_json: { name: :encounter_discharge_auth_token_header_json }
+               auth_tokens_header_json: { name: :encounter_discharge_auth_tokens_header_json }
              },
              outputs: {
                crd_jwks_json: { name: :encounter_discharge_crd_jwks_json },
@@ -313,40 +293,36 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_token_header_json: { name: :encounter_discharge_auth_token_header_json },
+               auth_tokens_header_json: { name: :encounter_discharge_auth_tokens_header_json },
                crd_jwks_keys_json: { name: :encounter_discharge_crd_jwks_keys_json }
              },
              outputs: {
-               auth_token_jwk_json: { name: :encounter_discharge_auth_token_jwk_json }
+               auth_tokens_jwk_json: { name: :encounter_discharge_auth_tokens_jwk_json }
              }
            }
       test from: :crd_token_payload,
            config: {
              options: { hook_path: ENCOUNTER_DISCHARGE_PATH },
              inputs: {
-               auth_token: { name: :encounter_discharge_auth_token },
-               auth_token_jwk_json: { name: :encounter_discharge_auth_token_jwk_json }
+               auth_tokens: { name: :encounter_discharge_auth_tokens },
+               auth_tokens_jwk_json: { name: :encounter_discharge_auth_tokens_jwk_json }
              }
            }
 
       test from: :crd_hook_request_required_fields,
            config: {
              options: {
-               hook_path: ENCOUNTER_DISCHARGE_PATH,
                hook_name: 'encounter-discharge'
-             },
-             requests: {
-               hook_request: { name: :encounter_discharge }
              }
            }
       test from: :crd_hook_request_optional_fields,
            config: {
+             options: {
+               hook_name: 'encounter-discharge'
+             },
              outputs: {
                client_fhir_server: { name: :encounter_discharge_client_fhir_server },
                client_access_token: { name: :encounter_discharge_client_access_token }
-             },
-             requests: {
-               hook_request: { name: :encounter_discharge }
              }
            }
 
@@ -356,18 +332,12 @@ module DaVinciCRDTestKit
                client_fhir_server: { name: :encounter_discharge_client_fhir_server },
                client_access_token: { name: :encounter_discharge_client_access_token }
              },
-             options: { hook_name: 'encounter-discharge' },
-             requests: {
-               hook_request: { name: :encounter_discharge }
-             }
+             options: { hook_name: 'encounter-discharge' }
            }
 
       test from: :crd_hook_request_valid_prefetch,
            config: {
-             options: { hook_name: 'encounter-discharge' },
-             requests: {
-               hook_request: { name: :encounter_discharge }
-             }
+             options: { hook_name: 'encounter-discharge' }
            }
 
       test from: :crd_card_display_attest_test,
@@ -399,20 +369,19 @@ module DaVinciCRDTestKit
 
       test from: :crd_decode_auth_token,
            config: {
-             requests: {
-               hook_request: { name: :order_select }
+             options: {
+               hook_name: 'order-select'
              },
              outputs: {
-               auth_token: { name: :order_select_auth_token },
-               auth_token_payload_json: { name: :order_select_auth_token_payload_json },
-               auth_token_header_json: { name: :order_select_auth_token_header_json }
+               auth_tokens: { name: :order_select_auth_tokens },
+               auth_token_payloads_json: { name: :order_select_auth_token_payloads_json },
+               auth_tokens_header_json: { name: :order_select_auth_tokens_header_json }
              }
            }
-
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_token_header_json: { name: :order_select_auth_token_header_json }
+               auth_tokens_header_json: { name: :order_select_auth_tokens_header_json }
              },
              outputs: {
                crd_jwks_json: { name: :order_select_crd_jwks_json },
@@ -422,40 +391,36 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_token_header_json: { name: :order_select_auth_token_header_json },
+               auth_tokens_header_json: { name: :order_select_auth_tokens_header_json },
                crd_jwks_keys_json: { name: :order_select_crd_jwks_keys_json }
              },
              outputs: {
-               auth_token_jwk_json: { name: :order_select_auth_token_jwk_json }
+               auth_tokens_jwk_json: { name: :order_select_auth_tokens_jwk_json }
              }
            }
       test from: :crd_token_payload,
            config: {
              options: { hook_path: ORDER_SELECT_PATH },
              inputs: {
-               auth_token: { name: :order_select_auth_token },
-               auth_token_jwk_json: { name: :order_select_auth_token_jwk_json }
+               auth_tokens: { name: :order_select_auth_tokens },
+               auth_tokens_jwk_json: { name: :order_select_auth_tokens_jwk_json }
              }
            }
 
       test from: :crd_hook_request_required_fields,
            config: {
              options: {
-               hook_path: ORDER_SELECT_PATH,
                hook_name: 'order-select'
-             },
-             requests: {
-               hook_request: { name: :order_select }
              }
            }
       test from: :crd_hook_request_optional_fields,
            config: {
+             options: {
+               hook_name: 'order-select'
+             },
              outputs: {
                client_fhir_server: { name: :order_select_client_fhir_server },
                client_access_token: { name: :order_select_client_access_token }
-             },
-             requests: {
-               hook_request: { name: :order_select }
              }
            }
 
@@ -465,18 +430,12 @@ module DaVinciCRDTestKit
                client_fhir_server: { name: :order_select_client_fhir_server },
                client_access_token: { name: :order_select_client_access_token }
              },
-             options: { hook_name: 'order-select' },
-             requests: {
-               hook_request: { name: :order_select }
-             }
+             options: { hook_name: 'order-select' }
            }
 
       test from: :crd_hook_request_valid_prefetch,
            config: {
-             options: { hook_name: 'order-select' },
-             requests: {
-               hook_request: { name: :order_select }
-             }
+             options: { hook_name: 'order-select' }
            }
 
       test from: :crd_card_display_attest_test,
@@ -507,20 +466,19 @@ module DaVinciCRDTestKit
 
       test from: :crd_decode_auth_token,
            config: {
-             requests: {
-               hook_request: { name: :order_dispatch }
+             options: {
+               hook_name: 'order-dispatch'
              },
              outputs: {
-               auth_token: { name: :order_dispatch_auth_token },
-               auth_token_payload_json: { name: :order_dispatch_auth_token_payload_json },
-               auth_token_header_json: { name: :order_dispatch_auth_token_header_json }
+               auth_tokens: { name: :order_dispatch_auth_tokens },
+               auth_token_payloads_json: { name: :order_dispatch_auth_token_payloads_json },
+               auth_tokens_header_json: { name: :order_dispatch_auth_tokens_header_json }
              }
            }
-
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_token_header_json: { name: :order_dispatch_auth_token_header_json }
+               auth_tokens_header_json: { name: :order_dispatch_auth_tokens_header_json }
              },
              outputs: {
                crd_jwks_json: { name: :order_dispatch_crd_jwks_json },
@@ -530,40 +488,36 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_token_header_json: { name: :order_dispatch_auth_token_header_json },
+               auth_tokens_header_json: { name: :order_dispatch_auth_tokens_header_json },
                crd_jwks_keys_json: { name: :order_dispatch_crd_jwks_keys_json }
              },
              outputs: {
-               auth_token_jwk_json: { name: :order_dispatch_auth_token_jwk_json }
+               auth_tokens_jwk_json: { name: :order_dispatch_auth_tokens_jwk_json }
              }
            }
       test from: :crd_token_payload,
            config: {
              options: { hook_path: ORDER_DISPATCH_PATH },
              inputs: {
-               auth_token: { name: :order_dispatch_auth_token },
-               auth_token_jwk_json: { name: :order_dispatch_auth_token_jwk_json }
+               auth_tokens: { name: :order_dispatch_auth_tokens },
+               auth_tokens_jwk_json: { name: :order_dispatch_auth_tokens_jwk_json }
              }
            }
 
       test from: :crd_hook_request_required_fields,
            config: {
              options: {
-               hook_path: ORDER_DISPATCH_PATH,
                hook_name: 'order-dispatch'
-             },
-             requests: {
-               hook_request: { name: :order_dispatch }
              }
            }
       test from: :crd_hook_request_optional_fields,
            config: {
+             options: {
+               hook_name: 'order-dispatch'
+             },
              outputs: {
                client_fhir_server: { name: :order_dispatch_client_fhir_server },
                client_access_token: { name: :order_dispatch_client_access_token }
-             },
-             requests: {
-               hook_request: { name: :order_dispatch }
              }
            }
 
@@ -573,18 +527,12 @@ module DaVinciCRDTestKit
                client_fhir_server: { name: :order_dispatch_client_fhir_server },
                client_access_token: { name: :order_dispatch_client_access_token }
              },
-             options: { hook_name: 'order-dispatch' },
-             requests: {
-               hook_request: { name: :order_dispatch }
-             }
+             options: { hook_name: 'order-dispatch' }
            }
 
       test from: :crd_hook_request_valid_prefetch,
            config: {
-             options: { hook_name: 'order-dispatch' },
-             requests: {
-               hook_request: { name: :order_dispatch }
-             }
+             options: { hook_name: 'order-dispatch' }
            }
 
       test from: :crd_card_display_attest_test,
@@ -616,19 +564,19 @@ module DaVinciCRDTestKit
 
       test from: :crd_decode_auth_token,
            config: {
-             requests: {
-               hook_request: { name: :order_sign }
+             options: {
+               hook_name: 'order-sign'
              },
              outputs: {
-               auth_token: { name: :order_sign_auth_token },
-               auth_token_payload_json: { name: :order_sign_auth_token_payload_json },
-               auth_token_header_json: { name: :order_sign_auth_token_header_json }
+               auth_tokens: { name: :order_sign_auth_tokens },
+               auth_token_payloads_json: { name: :order_sign_auth_token_payloads_json },
+               auth_tokens_header_json: { name: :order_sign_auth_tokens_header_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_token_header_json: { name: :order_sign_auth_token_header_json }
+               auth_tokens_header_json: { name: :order_sign_auth_tokens_header_json }
              },
              outputs: {
                crd_jwks_json: { name: :order_sign_crd_jwks_json },
@@ -638,40 +586,36 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_token_header_json: { name: :order_sign_auth_token_header_json },
+               auth_tokens_header_json: { name: :order_sign_auth_tokens_header_json },
                crd_jwks_keys_json: { name: :order_sign_crd_jwks_keys_json }
              },
              outputs: {
-               auth_token_jwk_json: { name: :order_sign_auth_token_jwk_json }
+               auth_tokens_jwk_json: { name: :order_sign_auth_tokens_jwk_json }
              }
            }
       test from: :crd_token_payload,
            config: {
              options: { hook_path: ORDER_SIGN_PATH },
              inputs: {
-               auth_token: { name: :order_sign_auth_token },
-               auth_token_jwk_json: { name: :order_sign_auth_token_jwk_json }
+               auth_tokens: { name: :order_sign_auth_tokens },
+               auth_tokens_jwk_json: { name: :order_sign_auth_tokens_jwk_json }
              }
            }
 
       test from: :crd_hook_request_required_fields,
            config: {
              options: {
-               hook_path: ORDER_SIGN_PATH,
                hook_name: 'order-sign'
-             },
-             requests: {
-               hook_request: { name: :order_sign }
              }
            }
       test from: :crd_hook_request_optional_fields,
            config: {
+             options: {
+               hook_name: 'order-sign'
+             },
              outputs: {
                client_fhir_server: { name: :order_sign_client_fhir_server },
                client_access_token: { name: :order_sign_client_access_token }
-             },
-             requests: {
-               hook_request: { name: :order_sign }
              }
            }
 
@@ -681,18 +625,12 @@ module DaVinciCRDTestKit
                client_fhir_server: { name: :order_sign_client_fhir_server },
                client_access_token: { name: :order_sign_client_access_token }
              },
-             options: { hook_name: 'order-sign' },
-             requests: {
-               hook_request: { name: :order_sign }
-             }
+             options: { hook_name: 'order-sign' }
            }
 
       test from: :crd_hook_request_valid_prefetch,
            config: {
-             options: { hook_name: 'order-sign' },
-             requests: {
-               hook_request: { name: :order_sign }
-             }
+             options: { hook_name: 'order-sign' }
            }
 
       test from: :crd_card_display_attest_test,

--- a/lib/davinci_crd_test_kit/client_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/client_hooks_group.rb
@@ -82,13 +82,13 @@ module DaVinciCRDTestKit
              outputs: {
                auth_tokens: { name: :appointment_book_auth_tokens },
                auth_token_payloads_json: { name: :appointment_book_auth_token_payloads_json },
-               auth_tokens_header_json: { name: :appointment_book_auth_tokens_header_json }
+               auth_token_headers_json: { name: :appointment_book_auth_token_headers_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :appointment_book_auth_tokens_header_json }
+               auth_token_headers_json: { name: :appointment_book_auth_token_headers_json }
              },
              outputs: {
                crd_jwks_json: { name: :appointment_book_crd_jwks_json },
@@ -98,7 +98,7 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :appointment_book_auth_tokens_header_json },
+               auth_token_headers_json: { name: :appointment_book_auth_token_headers_json },
                crd_jwks_keys_json: { name: :appointment_book_crd_jwks_keys_json }
              },
              outputs: {
@@ -179,13 +179,13 @@ module DaVinciCRDTestKit
              outputs: {
                auth_tokens: { name: :encounter_start_auth_tokens },
                auth_token_payloads_json: { name: :encounter_start_auth_token_payloads_json },
-               auth_tokens_header_json: { name: :encounter_start_auth_tokens_header_json }
+               auth_token_headers_json: { name: :encounter_start_auth_token_headers_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :encounter_start_auth_tokens_header_json }
+               auth_token_headers_json: { name: :encounter_start_auth_token_headers_json }
              },
              outputs: {
                crd_jwks_json: { name: :encounter_start_crd_jwks_json },
@@ -195,7 +195,7 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :encounter_start_auth_tokens_header_json },
+               auth_token_headers_json: { name: :encounter_start_auth_token_headers_json },
                crd_jwks_keys_json: { name: :encounter_start_crd_jwks_keys_json }
              },
              outputs: {
@@ -277,13 +277,13 @@ module DaVinciCRDTestKit
              outputs: {
                auth_tokens: { name: :encounter_discharge_auth_tokens },
                auth_token_payloads_json: { name: :encounter_discharge_auth_token_payloads_json },
-               auth_tokens_header_json: { name: :encounter_discharge_auth_tokens_header_json }
+               auth_token_headers_json: { name: :encounter_discharge_auth_token_headers_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :encounter_discharge_auth_tokens_header_json }
+               auth_token_headers_json: { name: :encounter_discharge_auth_token_headers_json }
              },
              outputs: {
                crd_jwks_json: { name: :encounter_discharge_crd_jwks_json },
@@ -293,7 +293,7 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :encounter_discharge_auth_tokens_header_json },
+               auth_token_headers_json: { name: :encounter_discharge_auth_token_headers_json },
                crd_jwks_keys_json: { name: :encounter_discharge_crd_jwks_keys_json }
              },
              outputs: {
@@ -375,13 +375,13 @@ module DaVinciCRDTestKit
              outputs: {
                auth_tokens: { name: :order_select_auth_tokens },
                auth_token_payloads_json: { name: :order_select_auth_token_payloads_json },
-               auth_tokens_header_json: { name: :order_select_auth_tokens_header_json }
+               auth_token_headers_json: { name: :order_select_auth_token_headers_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :order_select_auth_tokens_header_json }
+               auth_token_headers_json: { name: :order_select_auth_token_headers_json }
              },
              outputs: {
                crd_jwks_json: { name: :order_select_crd_jwks_json },
@@ -391,7 +391,7 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :order_select_auth_tokens_header_json },
+               auth_token_headers_json: { name: :order_select_auth_token_headers_json },
                crd_jwks_keys_json: { name: :order_select_crd_jwks_keys_json }
              },
              outputs: {
@@ -472,13 +472,13 @@ module DaVinciCRDTestKit
              outputs: {
                auth_tokens: { name: :order_dispatch_auth_tokens },
                auth_token_payloads_json: { name: :order_dispatch_auth_token_payloads_json },
-               auth_tokens_header_json: { name: :order_dispatch_auth_tokens_header_json }
+               auth_token_headers_json: { name: :order_dispatch_auth_token_headers_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :order_dispatch_auth_tokens_header_json }
+               auth_token_headers_json: { name: :order_dispatch_auth_token_headers_json }
              },
              outputs: {
                crd_jwks_json: { name: :order_dispatch_crd_jwks_json },
@@ -488,7 +488,7 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :order_dispatch_auth_tokens_header_json },
+               auth_token_headers_json: { name: :order_dispatch_auth_token_headers_json },
                crd_jwks_keys_json: { name: :order_dispatch_crd_jwks_keys_json }
              },
              outputs: {
@@ -570,13 +570,13 @@ module DaVinciCRDTestKit
              outputs: {
                auth_tokens: { name: :order_sign_auth_tokens },
                auth_token_payloads_json: { name: :order_sign_auth_token_payloads_json },
-               auth_tokens_header_json: { name: :order_sign_auth_tokens_header_json }
+               auth_token_headers_json: { name: :order_sign_auth_token_headers_json }
              }
            }
       test from: :crd_retrieve_jwks,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :order_sign_auth_tokens_header_json }
+               auth_token_headers_json: { name: :order_sign_auth_token_headers_json }
              },
              outputs: {
                crd_jwks_json: { name: :order_sign_crd_jwks_json },
@@ -586,7 +586,7 @@ module DaVinciCRDTestKit
       test from: :crd_token_header,
            config: {
              inputs: {
-               auth_tokens_header_json: { name: :order_sign_auth_tokens_header_json },
+               auth_token_headers_json: { name: :order_sign_auth_token_headers_json },
                crd_jwks_keys_json: { name: :order_sign_crd_jwks_keys_json }
              },
              outputs: {

--- a/lib/davinci_crd_test_kit/client_tests/appointment_book_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/appointment_book_receive_request_test.rb
@@ -7,13 +7,13 @@ module DaVinciCRDTestKit
     id :crd_appointment_book_request
     title 'Request received for appointment-book hook'
     description %(
-        This test waits for an incoming [appointment-book](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#appointment-book)
-        hook request and responds to the client with the response types selected as an input. This hook is a 'primary'
+        This test waits for multiple incoming [appointment-book](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#appointment-book)
+        hook requests and responds to the client with the response types selected as an input. This hook is a 'primary'
         hook, meaning that CRD Servers SHALL, at minimum, return a [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/StructureDefinition-ext-coverage-information.html)
         system action for these hooks, even if the response indicates that further information is needed or that the
         level of detail provided is insufficient to determine coverage.
       )
-    receives_request :appointment_book
+    config options: { accepts_multiple_requests: true }
 
     input :iss
     input :appointment_book_selected_response_types,
@@ -59,11 +59,13 @@ module DaVinciCRDTestKit
         message: %(
           **Appointment Book CDS Service Test**:
 
-          Invoke the appointment-book hook and send a request to:
+          Invoke the appointment-book hook and send requests to:
 
           `#{appointment_book_url}`
 
-          Inferno will process the request and return CDS cards if successful.
+          Inferno will process the requests and return CDS cards if successful.
+
+          [Click here](#{resume_pass_url}?token=appointment-book%20#{iss}) when you have finished submitting requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/decode_auth_token_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/decode_auth_token_test.rb
@@ -25,10 +25,12 @@ module DaVinciCRDTestKit
       auth_token_headers_json = []
 
       requests.each_with_index do |request, index|
+        @request_number = index + 1
+
         authorization_header = request.request_header('Authorization')&.value
 
         unless authorization_header.start_with?('Bearer ')
-          add_message('error', "Request #{index + 1}: Authorization token must be a JWT presented as a `Bearer` token")
+          add_message('error', "#{request_number}Authorization token must be a JWT presented as a `Bearer` token")
         end
 
         auth_token = authorization_header.delete_prefix('Bearer ')
@@ -45,7 +47,7 @@ module DaVinciCRDTestKit
           auth_token_payloads_json << payload.to_json
           auth_token_headers_json << header.to_json
         rescue StandardError => e
-          add_message('error', "Request #{index + 1}: Token is not a properly constructed JWT: #{e.message}")
+          add_message('error', "#{request_number}Token is not a properly constructed JWT: #{e.message}")
         end
       end
       output auth_tokens: auth_tokens.to_json,

--- a/lib/davinci_crd_test_kit/client_tests/decode_auth_token_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/decode_auth_token_test.rb
@@ -1,5 +1,8 @@
+require_relative '../client_hook_request_validation'
+
 module DaVinciCRDTestKit
   class DecodeAuthTokenTest < Inferno::Test
+    include ClientHookRequestValidation
     id :crd_decode_auth_token
     title 'Bearer token can be decoded'
     description %(
@@ -58,9 +61,9 @@ module DaVinciCRDTestKit
              auth_tokens_header_json: auth_tokens_header_json.to_json
 
       error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
+        add_message('error', msg)
       end
-      assert error_messages.empty?, 'Decoding Authorization header Bearer tokens failed.'
+      no_error_validation('Decoding Authorization header Bearer tokens failed.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/encounter_discharge_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/encounter_discharge_receive_request_test.rb
@@ -7,10 +7,11 @@ module DaVinciCRDTestKit
     id :crd_encounter_discharge_request
     title 'Request received for encounter-discharge hook'
     description %(
-        This test waits for an incoming [encounter-discharge](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-discharge)
-        hook request and responds to the client with the response types selected as an input.
+        This test waits for multiple incoming [encounter-discharge](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-discharge)
+        hook requests and responds to the client with the response types selected as an input.
       )
-    receives_request :encounter_discharge
+
+    config options: { accepts_multiple_requests: true }
 
     input :iss
     input :encounter_discharge_selected_response_types,
@@ -56,11 +57,13 @@ module DaVinciCRDTestKit
         message: %(
           **Encounter Discharge CDS Service Test**:
 
-          Invoke the encounter-discharge hook and send a request to:
+          Invoke the encounter-discharge hook and send requests to:
 
           `#{encounter_discharge_url}`
 
-          Inferno will process the request and return CDS cards if successful.
+          Inferno will process the requests and return CDS cards if successful.
+
+          [Click here](#{resume_pass_url}?token=encounter-discharge%20#{iss}) when you have finished submitting requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/encounter_discharge_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/encounter_discharge_receive_request_test.rb
@@ -63,7 +63,8 @@ module DaVinciCRDTestKit
 
           Inferno will process the requests and return CDS cards if successful.
 
-          [Click here](#{resume_pass_url}?token=encounter-discharge%20#{iss}) when you have finished submitting requests.
+          [Click here](#{resume_pass_url}?token=encounter-discharge%20#{iss}) when you have finished submitting
+          requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/encounter_start_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/encounter_start_receive_request_test.rb
@@ -7,10 +7,11 @@ module DaVinciCRDTestKit
     id :crd_encounter_start_request
     title 'Request received for encounter-start hook'
     description %(
-      This test waits for an incoming [encounter-start](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-start)
-      hook request and responds to the client with the response types selected as an input.
+      This test waits for multiple incoming [encounter-start](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-start)
+      hook requests and responds to the client with the response types selected as an input.
       )
-    receives_request :encounter_start
+
+    config options: { accepts_multiple_requests: true }
 
     input :iss
     input :encounter_start_selected_response_types,
@@ -56,11 +57,13 @@ module DaVinciCRDTestKit
         message: %(
           **Encounter Start CDS Service Test**:
 
-          Invoke the encounter-start hook and send a request to:
+          Invoke the encounter-start hook and send requests to:
 
           `#{encounter_start_url}`
 
-          Inferno will process the request and return CDS cards if successful.
+          Inferno will process the requests and return CDS cards if successful.
+
+          [Click here](#{resume_pass_url}?token=enounter-start%20#{iss}) when you have finished submitting requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
@@ -36,10 +36,11 @@ module DaVinciCRDTestKit
       skip_if requests.empty?, "No #{hook_name} requests were made in a previous test as expected."
       client_fhir_server = nil
       requests.each_with_index do |request, index|
-        request_body = json_parse(request.request_body, index + 1)
-        next unless request_body
+        @request_number = index + 1
+        request_body = json_parse(request.request_body)
+        next if request_body.blank?
 
-        fhir_server_info = hook_request_optional_fields_check(request_body, index + 1)
+        fhir_server_info = hook_request_optional_fields_check(request_body)
         client_fhir_server ||= fhir_server_info
       end
 

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
@@ -2,7 +2,7 @@ require_relative '../client_hook_request_validation'
 
 module DaVinciCRDTestKit
   class HookRequestOptionalFieldsTest < Inferno::Test
-    include DaVinciCRDTestKit::ClientHookRequestValidation
+    include ClientHookRequestValidation
     include URLs
 
     id :crd_hook_request_optional_fields
@@ -51,9 +51,9 @@ module DaVinciCRDTestKit
       end
 
       error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
+        add_message('error', msg)
       end
-      assert error_messages.empty?, 'Some service requests contain invalid optional fields.'
+      no_error_validation('Some service requests contain invalid optional fields.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
@@ -34,24 +34,18 @@ module DaVinciCRDTestKit
     run do
       load_tagged_requests(hook_name)
       skip_if requests.empty?, "No #{hook_name} requests were made in a previous test as expected."
-      error_messages = []
       client_fhir_server = nil
       requests.each_with_index do |request, index|
-        assert_valid_json(request.request_body)
-        request_body = JSON.parse(request.request_body)
+        request_body = json_parse(request.request_body, index + 1)
+        next unless request_body
+
         fhir_server_info = hook_request_optional_fields_check(request_body, index + 1)
         client_fhir_server ||= fhir_server_info
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
       end
 
       unless client_fhir_server.nil?
         output client_fhir_server: client_fhir_server[:fhir_server_uri],
                client_access_token: client_fhir_server[:fhir_access_token]
-      end
-
-      error_messages.each do |msg|
-        add_message('error', msg)
       end
       no_error_validation('Some service requests contain invalid optional fields.')
     end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
@@ -3,6 +3,7 @@ require_relative '../client_hook_request_validation'
 module DaVinciCRDTestKit
   class HookRequestOptionalFieldsTest < Inferno::Test
     include DaVinciCRDTestKit::ClientHookRequestValidation
+    include URLs
 
     id :crd_hook_request_optional_fields
     title 'Hook request contains optional fields'
@@ -22,20 +23,37 @@ module DaVinciCRDTestKit
     )
     optional
 
+    def hook_name
+      config.options[:hook_name]
+    end
+
     output :client_fhir_server
     output :client_access_token,
            optional: true
 
-    uses_request :hook_request
-
     run do
-      assert_valid_json(request.request_body)
-      request_body = JSON.parse(request.request_body)
+      load_tagged_requests(hook_name)
+      skip_if requests.empty?, "No #{hook_name} requests were made in a previous test as expected."
+      error_messages = []
+      client_fhir_server = nil
+      requests.each_with_index do |request, index|
+        assert_valid_json(request.request_body)
+        request_body = JSON.parse(request.request_body)
+        fhir_server_info = hook_request_optional_fields_check(request_body, index + 1)
+        client_fhir_server ||= fhir_server_info
+      rescue Inferno::Exceptions::AssertionException => e
+        error_messages << "Request #{index + 1}: #{e.message}"
+      end
 
-      client_fhir_server = hook_request_optional_fields_check(request_body)
+      unless client_fhir_server.nil?
+        output client_fhir_server: client_fhir_server[:fhir_server_uri],
+               client_access_token: client_fhir_server[:fhir_access_token]
+      end
 
-      output client_fhir_server: client_fhir_server[:fhir_server_uri],
-             client_access_token: client_fhir_server[:fhir_access_token]
+      error_messages.each do |msg|
+        messages << { type: 'error', message: msg }
+      end
+      assert error_messages.empty?, 'Some service requests contain invalid optional fields.'
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_optional_fields_test.rb
@@ -38,7 +38,10 @@ module DaVinciCRDTestKit
       requests.each_with_index do |request, index|
         @request_number = index + 1
         request_body = json_parse(request.request_body)
-        next if request_body.blank?
+        if request_body.blank?
+          add_message('error', "#{request_number}Hook request body cannot be empty.")
+          next
+        end
 
         fhir_server_info = hook_request_optional_fields_check(request_body)
         client_fhir_server ||= fhir_server_info

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_required_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_required_fields_test.rb
@@ -20,21 +20,35 @@ module DaVinciCRDTestKit
         a request for
     )
 
-    uses_request :hook_request
-
-    def hook_url
-      base_url + config.options[:hook_path]
-    end
-
     def hook_name
       config.options[:hook_name]
     end
 
-    run do
-      assert_valid_json(request.request_body)
-      request_body = JSON.parse(request.request_body)
+    output :contexts_prefetches
 
-      hook_request_required_fields_check(request_body, hook_name)
+    run do
+      load_tagged_requests(hook_name)
+      skip_if requests.empty?, "No #{hook_name} requests were made in a previous test as expected."
+      error_messages = []
+      contexts_prefetches = []
+      requests.each_with_index do |request, index|
+        assert_valid_json(request.request_body)
+        request_body = JSON.parse(request.request_body)
+        context = request_body['context'] if request_body['context'].is_a?(Hash)
+        prefetch = request_body['prefetch'] if request_body['prefetch'].present? &&
+                                               request_body['prefetch'].is_a?(Hash)
+        contexts_prefetches << { context:, prefetch: }
+        hook_request_required_fields_check(request_body, hook_name)
+      rescue Inferno::Exceptions::AssertionException => e
+        error_messages << "Request #{index + 1}: #{e.message}"
+      end
+
+      output contexts_prefetches: contexts_prefetches.to_json
+
+      error_messages.each do |msg|
+        messages << { type: 'error', message: msg }
+      end
+      assert error_messages.empty?, 'Some service requests made are not valid.'
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_required_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_required_fields_test.rb
@@ -32,12 +32,13 @@ module DaVinciCRDTestKit
       contexts = []
       prefetches = []
       requests.each_with_index do |request, index|
-        request_body = json_parse(request.request_body, index + 1)
-        next unless request_body
+        @request_number = index + 1
+        request_body = json_parse(request.request_body)
+        next if request_body.blank?
 
         contexts << request_body['context'] if request_body['context'].is_a?(Hash)
         prefetches << request_body['prefetch'] if request_body['prefetch'].is_a?(Hash)
-        hook_request_required_fields_check(request_body, hook_name, index + 1)
+        hook_request_required_fields_check(request_body, hook_name)
       end
 
       output contexts: contexts.to_json,

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_required_fields_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_required_fields_test.rb
@@ -29,25 +29,19 @@ module DaVinciCRDTestKit
     run do
       load_tagged_requests(hook_name)
       skip_if requests.empty?, "No #{hook_name} requests were made in a previous test as expected."
-      error_messages = []
       contexts = []
       prefetches = []
       requests.each_with_index do |request, index|
-        assert_valid_json(request.request_body)
-        request_body = JSON.parse(request.request_body)
+        request_body = json_parse(request.request_body, index + 1)
+        next unless request_body
+
         contexts << request_body['context'] if request_body['context'].is_a?(Hash)
         prefetches << request_body['prefetch'] if request_body['prefetch'].is_a?(Hash)
-        hook_request_required_fields_check(request_body, hook_name)
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
+        hook_request_required_fields_check(request_body, hook_name, index + 1)
       end
 
       output contexts: contexts.to_json,
              prefetches: prefetches.to_json
-
-      error_messages.each do |msg|
-        add_message('error', msg)
-      end
       no_error_validation('Some service requests made are not valid.')
     end
   end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
@@ -55,7 +55,6 @@ module DaVinciCRDTestKit
       error_messages = []
       hook_contexts.each_with_index do |context, index|
         assert(context.present?, 'Missing required context field.')
-        assert(context.is_a?(Hash), 'Context is in an incorrect format.')
         hook_request_context_check(context, hook_name, index + 1)
       rescue Inferno::Exceptions::AssertionException => e
         error_messages << "Request #{index + 1}: #{e.message}"

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
@@ -49,19 +49,16 @@ module DaVinciCRDTestKit
     end
 
     run do
-      assert_valid_json(contexts)
-      hook_contexts = JSON.parse(contexts)
-      skip_if(hook_contexts.none?(&:present?), "No #{hook_name} requests contained the `context` field.")
-      error_messages = []
-      hook_contexts.each_with_index do |context, index|
-        assert(context.present?, 'Missing required context field.')
-        hook_request_context_check(context, hook_name, index + 1)
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
-      end
+      hook_contexts = json_parse(contexts)
+      next unless hook_contexts
 
-      error_messages.each do |msg|
-        add_message('error', msg)
+      skip_if(hook_contexts.none?(&:present?), "No #{hook_name} requests contained the `context` field.")
+      hook_contexts.each_with_index do |context, index|
+        unless context.present?
+          add_message('error', "Request #{index + 1}: Missing required context field.")
+          next
+        end
+        hook_request_context_check(context, hook_name, index + 1)
       end
       no_error_validation('Context is not valid.')
     end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
@@ -50,15 +50,16 @@ module DaVinciCRDTestKit
 
     run do
       hook_contexts = json_parse(contexts)
-      next unless hook_contexts
-
-      skip_if(hook_contexts.none?(&:present?), "No #{hook_name} requests contained the `context` field.")
-      hook_contexts.each_with_index do |context, index|
-        unless context.present?
-          add_message('error', "Request #{index + 1}: Missing required context field.")
-          next
+      if hook_contexts
+        skip_if(hook_contexts.none?(&:present?), "No #{hook_name} requests contained the `context` field.")
+        hook_contexts.each_with_index do |context, index|
+          @request_number = index + 1
+          if context.blank?
+            add_message('error', "Request #{index + 1}: Missing required context field.")
+            next
+          end
+          hook_request_context_check(context, hook_name)
         end
-        hook_request_context_check(context, hook_name, index + 1)
       end
       no_error_validation('Context is not valid.')
     end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_context_test.rb
@@ -55,7 +55,7 @@ module DaVinciCRDTestKit
         hook_contexts.each_with_index do |context, index|
           @request_number = index + 1
           if context.blank?
-            add_message('error', "Request #{index + 1}: Missing required context field.")
+            add_message('error', "#{request_number}Missing required context field.")
             next
           end
           hook_request_context_check(context, hook_name)

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_prefetch_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_prefetch_test.rb
@@ -51,9 +51,9 @@ module DaVinciCRDTestKit
           @request_number = index + 1
           context = hook_contexts[index]
 
-          info "Request #{index + 1}: Received hook request does not contain the `prefetch` field." if prefetch.blank?
+          info "#{request_number}Received hook request does not contain the `prefetch` field." if prefetch.blank?
           if context.blank?
-            info %(Request #{index + 1}: Received hook request does not contain the `context` field
+            info %(#{request_number}Received hook request does not contain the `context` field
             which is needed to validate the `prefetch` field)
           end
 

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_prefetch_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_prefetch_test.rb
@@ -2,6 +2,7 @@ require_relative '../urls'
 
 module DaVinciCRDTestKit
   class HookRequestValidPrefetchTest < Inferno::Test
+    include DaVinciCRDTestKit::ClientHookRequestValidation
     include URLs
 
     id :crd_hook_request_valid_prefetch
@@ -19,7 +20,7 @@ module DaVinciCRDTestKit
     )
     optional
 
-    uses_request :hook_request
+    input :contexts_prefetches
 
     def hook_name
       config.options[:hook_name]
@@ -31,121 +32,41 @@ module DaVinciCRDTestKit
                            )))['services']
     end
 
-    def structure_definition_map
-      {
-        'Practitioner' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-practitioner',
-        'PractitionerRole' => 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole',
-        'Patient' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-patient',
-        'Coverage' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-coverage',
-        'RelatedPerson' => 'http://hl7.org/fhir/StructureDefinition/RelatedPerson',
-        'Encounter' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-encounter',
-        'DeviceRequest' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-devicerequest',
-        'MedicationRequest' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-medicationrequest',
-        'NutritionOrder' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-nutritionorder',
-        'ServiceRequest' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-servicerequest',
-        'VisionPrescription' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-visionprescription'
-      }
-    end
-
-    def validate_prefetch_coverage(received_resource, advertised_prefetch_key,
-                                   received_context_patient_id, advertised_status)
-      assert_resource_type('Bundle', resource: received_resource)
-      assert(received_resource.entry.any?, 'Bundle of coverage resources received from prefetch is empty')
-      coverage_resource = received_resource.entry.first.resource
-      assert_resource_type('Coverage', resource: coverage_resource)
-      assert_valid_resource(resource: coverage_resource,
-                            profile_url: structure_definition_map['Coverage'])
-
-      coverage_beneficiary_reference = coverage_resource.beneficiary
-      coverage_beneficiary_patient_id = coverage_beneficiary_reference.reference_id
-      assert(coverage_beneficiary_patient_id.present?,
-             "Could not get beneficiary reference id from `#{advertised_prefetch_key}` field's Coverage resource")
-
-      assert(coverage_beneficiary_patient_id == received_context_patient_id,
-             %(Expected `#{advertised_prefetch_key}` field's Coverage resource to have a `beneficiary` reference id of
-             '#{received_context_patient_id}', instead was '#{coverage_beneficiary_patient_id}'))
-
-      coverage_status = coverage_resource.status
-      assert(coverage_status == advertised_status,
-             %(Expected `#{advertised_prefetch_key}` field's Coverage resource to have a `status` of
-             '#{advertised_status}', instead was '#{coverage_status}'))
-    end
-
-    def validate_prefetch_resource(received_resource, advertised_prefetch_key, context_field_resource_type,
-                                   context_field_id)
-      assert_resource_type(context_field_resource_type, resource: received_resource)
-
-      if hook_name == 'order-dispatch'
-        assert_valid_resource(resource: received_resource)
-      else
-        assert_valid_resource(resource: received_resource,
-                              profile_url: structure_definition_map[context_field_resource_type])
-      end
-
-      received_prefetch_resource_id = received_resource.id
-      assert(received_prefetch_resource_id.present?,
-             "`#{advertised_prefetch_key}` field's FHIR resource does not contain the `id` field")
-      assert(received_prefetch_resource_id == context_field_id,
-             %(Expected `#{advertised_prefetch_key}` field's FHIR resource to have an `id` of '#{context_field_id}',
-             instead was '#{received_prefetch_resource_id}'))
+    def advertised_prefetch_fields
+      advertised_hook_service = cds_services_json.find { |service| service['hook'] == hook_name }
+      advertised_hook_service['prefetch']
     end
 
     run do
-      assert_valid_json(request.request_body)
-      request_body = JSON.parse(request.request_body)
+      assert_valid_json(contexts_prefetches)
+      hook_contexts_prefetches = JSON.parse(contexts_prefetches)
+      skip_if(hook_contexts_prefetches.none? do |context_prefetch|
+                context_prefetch['prefetch'].present? && context_prefetch['context'].present?
+              end,
+              "No #{hook_name} requests contained both the `context` and `prefetch` field.")
+      error_messages = []
+      hook_contexts_prefetches.each_with_index do |context_prefetch, index|
+        received_prefetch = context_prefetch['prefetch']
+        received_context = context_prefetch['context']
 
-      received_prefetch = request_body['prefetch']
-      received_context = request_body['context']
-
-      skip_if received_prefetch.blank?, 'Received hook request does not contain the `prefetch` field.'
-      skip_if received_context.blank?,
-              %(Received hook request does not contain the `context` field which is needed to validate the `prefetch`
-              field)
-
-      advertised_hook_service = cds_services_json.find { |service| service['hook'] == hook_name }
-
-      advertised_prefetch_fields = advertised_hook_service['prefetch']
-
-      advertised_prefetch_fields.each do |advertised_prefetch_key, advertised_prefetch_template|
-        next unless received_prefetch[advertised_prefetch_key].present?
-
-        assert(received_prefetch[advertised_prefetch_key].is_a?(Hash),
-               "Prefetch field `#{advertised_prefetch_key}` is not of type `Hash`.")
-
-        received_prefetch_resource = FHIR.from_contents(received_prefetch[advertised_prefetch_key].to_json)
-
-        if advertised_prefetch_template.include?('?')
-          advertised_prefetch_fhir_search = advertised_prefetch_template.gsub(/{|}/, '').split('?')
-          advertised_prefetch_resource_type = advertised_prefetch_fhir_search.first
-
-          if advertised_prefetch_resource_type == 'Coverage'
-            advertised_coverage_query_params = Rack::Utils.parse_nested_query(advertised_prefetch_fhir_search.last)
-
-            advertised_patient_token = advertised_coverage_query_params['patient']
-            advertised_context_patient_id_key = advertised_patient_token.split('.').last
-            received_context_patient_id = received_context[advertised_context_patient_id_key]
-
-            advertised_status_param = advertised_coverage_query_params['status']
-
-            validate_prefetch_coverage(received_prefetch_resource, advertised_prefetch_key, received_context_patient_id,
-                                       advertised_status_param)
-          end
-        else
-          advertised_prefetch_token = advertised_prefetch_template.gsub(/{|}/, '').split('/')
-          advertised_context_id = advertised_prefetch_token.last.split('.').last
-
-          if advertised_prefetch_token.length == 1
-            received_context_reference = FHIR::Reference.new(reference: received_context[advertised_context_id])
-            received_context_resource_type = received_context_reference.resource_type
-            received_context_id = received_context_reference.reference_id
-          else
-            received_context_id = received_context[advertised_context_id]
-            received_context_resource_type = advertised_prefetch_token.first
-          end
-          validate_prefetch_resource(received_prefetch_resource, advertised_prefetch_key,
-                                     received_context_resource_type, received_context_id)
+        info do
+          assert received_prefetch.present?, "Received hook request #{index + 1} does not contain the `prefetch` field."
+          assert received_context.present?, %(Received hook request  #{index + 1} does not contain the `context` field
+          which is needed to validate the `prefetch` field)
         end
+
+        next if received_prefetch.blank? || received_context.blank?
+
+        hook_request_prefetch_check(advertised_prefetch_fields, received_prefetch, received_context)
+        no_error_validation('Prefetch is not valid.')
+      rescue Inferno::Exceptions::AssertionException => e
+        error_messages << "Request #{index + 1}: #{e.message}"
       end
+
+      error_messages.each do |msg|
+        messages << { type: 'error', message: msg }
+      end
+      assert error_messages.empty?, 'Prefetch is not valid.'
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/hook_request_valid_prefetch_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/hook_request_valid_prefetch_test.rb
@@ -38,35 +38,31 @@ module DaVinciCRDTestKit
     end
 
     run do
-      assert_valid_json(contexts)
-      assert_valid_json(prefetches)
+      hook_contexts = json_parse(contexts)
+      next unless hook_contexts
 
-      hook_contexts = JSON.parse(contexts)
-      hook_prefetches = JSON.parse(prefetches)
+      hook_prefetches = json_parse(prefetches)
+      next unless hook_prefetches
 
       skip_if(hook_prefetches.none? do |prefetch|
         prefetch_index = hook_prefetches.find_index(prefetch)
         prefetch.present? && hook_contexts[prefetch_index].present?
       end, "No #{hook_name} requests contained both the `context` and `prefetch` field.")
-      error_messages = []
+
       hook_prefetches.each_with_index do |prefetch, index|
         context = hook_contexts[index]
 
-        info do
-          assert prefetch.present?, "Received hook request #{index + 1} does not contain the `prefetch` field."
-          assert context.present?, %(Received hook request  #{index + 1} does not contain the `context` field
-          which is needed to validate the `prefetch` field)
+        unless prefetch.present?
+          add_message('info', "Request #{index + 1}: Received hook request does not contain the `prefetch` field.")
+        end
+        unless context.present?
+          add_message('info', %(Request #{index + 1}: Received hook request does not contain the `context` field
+          which is needed to validate the `prefetch` field))
         end
 
         next if prefetch.blank? || context.blank?
 
-        hook_request_prefetch_check(advertised_prefetch_fields, prefetch, context)
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
-      end
-
-      error_messages.each do |msg|
-        add_message('error', msg)
+        hook_request_prefetch_check(advertised_prefetch_fields, prefetch, context, index + 1)
       end
       no_error_validation('Prefetch is not valid.')
     end

--- a/lib/davinci_crd_test_kit/client_tests/order_dispatch_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/order_dispatch_receive_request_test.rb
@@ -7,13 +7,14 @@ module DaVinciCRDTestKit
     id :crd_order_dispatch_request
     title 'Request received for order-dispatch hook'
     description %(
-        This test waits for an incoming [order-dispatch](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-dispatch)
-        hook request and responds to the client with the response types selected as an input. This hook is a 'primary'
+        This test waits for multiple incoming [order-dispatch](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-dispatch)
+        hook requests and responds to the client with the response types selected as an input. This hook is a 'primary'
         hook, meaning that CRD Servers SHALL, at minimum, return a [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/StructureDefinition-ext-coverage-information.html)
         system action for these hooks, even if the response indicates that further information is needed or that the
         level of detail provided is insufficient to determine coverage.
       )
-    receives_request :order_dispatch
+
+    config options: { accepts_multiple_requests: true }
 
     input :iss
     input :order_dispatch_selected_response_types,
@@ -67,11 +68,13 @@ module DaVinciCRDTestKit
         message: %(
           **Order Dispatch CDS Service Test**:
 
-          Invoke the order-dispatch hook and send a request to:
+          Invoke the order-dispatch hook and send requests to:
 
           `#{order_dispatch_url}`
 
-          Inferno will process the request and return CDS cards if successful.
+          Inferno will process the requests and return CDS cards if successful.
+
+          [Click here](#{resume_pass_url}?token=order-dispatch%20#{iss}) when you have finished submitting requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/order_select_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/order_select_receive_request_test.rb
@@ -7,10 +7,11 @@ module DaVinciCRDTestKit
     id :crd_order_select_request
     title 'Request received for order-select hook'
     description %(
-      This test waits for an incoming [order-select](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-select)
-      hook request and responds to the client with the response types selected as an input.
+      This test waits for multiple incoming [order-select](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-select)
+      hook requests and responds to the client with the response types selected as an input.
       )
-    receives_request :order_select
+
+    config options: { accepts_multiple_requests: true }
 
     input :iss
     input :order_select_selected_response_types,
@@ -64,11 +65,13 @@ module DaVinciCRDTestKit
         message: %(
           **Order Select CDS Service Test**:
 
-          Invoke the order-select hook and send a request to:
+          Invoke the order-select hook and send requests to:
 
           `#{order_select_url}`
 
-          Inferno will process the request and return CDS cards if successful.
+          Inferno will process the requests and return CDS cards if successful.
+
+          [Click here](#{resume_pass_url}?token=order-select%20#{iss}) when you have finished submitting requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/order_sign_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/order_sign_receive_request_test.rb
@@ -7,13 +7,14 @@ module DaVinciCRDTestKit
     id :crd_order_sign_request
     title 'Request received for order-sign hook'
     description %(
-        This test waits for an incoming [order-sign](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-sign)
-        hook request and responds to the client with the response types selected as an input. This hook is a 'primary'
+        This test waits for multiple incoming [order-sign](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-sign)
+        hook requests and responds to the client with the response types selected as an input. This hook is a 'primary'
         hook, meaning that CRD Servers SHALL, at minimum, return a [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/StructureDefinition-ext-coverage-information.html)
         system action for these hooks, even if the response indicates that further information is needed or that the
         level of detail provided is insufficient to determine coverage.
       )
-    receives_request :order_sign
+
+    config options: { accepts_multiple_requests: true }
 
     input :iss
     input :order_sign_selected_response_types,
@@ -67,11 +68,13 @@ module DaVinciCRDTestKit
         message: %(
           **Order Sign CDS Service Test**:
 
-          Invoke the order-sign hook and send a request to:
+          Invoke the order-sign hook and send requests to:
 
           `#{order_sign_url}`
 
-          Inferno will process the request and return CDS cards if successful.
+          Inferno will process the requests and return CDS cards if successful.
+
+          [Click here](#{resume_pass_url}?token=order-sign%20#{iss}) when you have finished submitting requests.
         )
       )
     end

--- a/lib/davinci_crd_test_kit/client_tests/retrieve_jwks_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/retrieve_jwks_test.rb
@@ -1,5 +1,9 @@
+require_relative '../client_hook_request_validation'
+
 module DaVinciCRDTestKit
   class RetrieveJWKSTest < Inferno::Test
+    include ClientHookRequestValidation
+
     id :crd_retrieve_jwks
     title 'JWKS can be retrieved'
     description %(
@@ -72,9 +76,9 @@ module DaVinciCRDTestKit
              crd_jwks_keys_json: crd_jwks_keys_json.to_json
 
       error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
+        add_message('error', msg)
       end
-      assert error_messages.empty?, 'Retrieving JWKS failed.'
+      no_error_validation('Retrieving JWKS failed.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/retrieve_jwks_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/retrieve_jwks_test.rb
@@ -10,7 +10,7 @@ module DaVinciCRDTestKit
         submit the jwk_set as an input to the test.
       )
 
-    input :auth_token_header_json
+    input :auth_tokens_header_json
     input :jwk_set,
           title: "The Client's JWK Set containing it's public key",
           description: %(
@@ -20,46 +20,61 @@ module DaVinciCRDTestKit
           type: 'textarea',
           optional: true
     output :crd_jwks_json, :crd_jwks_keys_json
-    makes_request :crd_client_jwks
 
     run do
-      token_header = JSON.parse(auth_token_header_json)
-      jku = token_header['jku']
+      auth_token_headers = JSON.parse(auth_tokens_header_json)
+      skip_if auth_token_headers.empty?, 'No Authorization tokens produced from the previous test.'
 
-      if jku.present?
-        get(jku, name: :crd_client_jwks)
+      error_messages = []
+      crd_jwks_json = []
+      crd_jwks_keys_json = []
+      auth_token_headers.each_with_index do |token_header, index|
+        jku = JSON.parse(token_header)['jku']
+        if jku.present?
+          get(jku)
 
-        assert_response_status(200)
-        assert_valid_json(response[:body])
-        output crd_jwks_json: response[:body]
+          assert_response_status(200)
+          assert_valid_json(response[:body])
+          crd_jwks_json << response[:body]
 
-        jwks = JSON.parse(response[:body])
-      else
-        skip_if jwk_set.blank?,
-                %(JWK Set must be inputted if Client's JWK Set is not available via a URL identified by the jku header
-                field)
+          jwks = JSON.parse(response[:body])
+        else
+          skip_if jwk_set.blank?,
+                  %(JWK Set must be inputted if Client's JWK Set is not available via a URL identified by the jku header
+                  field)
 
-        jwks = JSON.parse(jwk_set)
+          jwks = JSON.parse(jwk_set)
+        end
+
+        keys = jwks['keys']
+        assert keys.is_a?(Array), 'JWKS `keys` field must be an array'
+
+        assert keys.present?, 'The JWK set returned contains no public keys'
+
+        keys.each do |jwk|
+          JWT::JWK.import(jwk.deep_symbolize_keys)
+        rescue StandardError
+          assert false, "Invalid JWK: #{jwk.to_json}"
+        end
+
+        kid_presence = keys.all? { |key| key['kid'].present? }
+        assert kid_presence, '`kid` field must be present in each key if JWKS contains multiple keys'
+
+        kid_uniqueness = keys.map { |key| key['kid'] }.uniq.length == keys.length
+        assert kid_uniqueness, '`kid` must be unique within the client\' JWK Set.'
+
+        crd_jwks_keys_json << keys.to_json
+      rescue Inferno::Exceptions::AssertionException => e
+        error_messages << "Request #{index + 1}: #{e.message}"
       end
 
-      keys = jwks['keys']
-      assert keys.is_a?(Array), 'JWKS `keys` field must be an array'
+      output crd_jwks_json: crd_jwks_json.to_json,
+             crd_jwks_keys_json: crd_jwks_keys_json.to_json
 
-      assert keys.present?, 'The JWK set returned contains no public keys'
-
-      keys.each do |jwk|
-        JWT::JWK.import(jwk.deep_symbolize_keys)
-      rescue StandardError
-        assert false, "Invalid JWK: #{jwk.to_json}"
+      error_messages.each do |msg|
+        messages << { type: 'error', message: msg }
       end
-
-      kid_presence = keys.all? { |key| key['kid'].present? }
-      assert kid_presence, '`kid` field must be present in each key if JWKS contains multiple keys'
-
-      kid_uniqueness = keys.map { |key| key['kid'] }.uniq.length == keys.length
-      assert kid_uniqueness, '`kid` must be unique within the client\' JWK Set.'
-
-      output crd_jwks_keys_json: keys.to_json
+      assert error_messages.empty?, 'Retrieving JWKS failed.'
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
@@ -21,34 +21,51 @@ module DaVinciCRDTestKit
       skip_if auth_token_headers.empty?, 'No Authorization tokens produced from the previous tests.'
       skip_if auth_token_headers.empty?, 'No JWKS keys produced from the previous test.'
 
-      error_messages = []
       auth_tokens_jwk_json = []
       auth_token_headers.each_with_index do |token_header, index|
         header = JSON.parse(token_header)
         algorithm = header['alg']
-        assert algorithm.present?, 'Token header must have the `alg` field'
-        assert algorithm != 'none', 'Token header `alg` field cannot be set to none'
+        unless algorithm.present?
+          add_message('error', "Request #{index + 1}: Token header must have the `alg` field")
+          next
+        end
 
-        assert header['typ'].present?, 'Token header must have the `typ` field'
-        assert header['typ'] == 'JWT', "Token header `typ` field must be set to 'JWT', instead was #{header['typ']}"
+        if algorithm == 'none'
+          add_message('error', "Request #{index + 1}: Token header `alg` field cannot be set to none")
+          next
+        end
 
-        assert header['kid'].present?, 'Token header must have the `kid` field'
+        unless header['typ'].present?
+          add_message('error', "Request #{index + 1}: Token header must have the `typ` field")
+          next
+        end
+
+        if header['typ'] != 'JWT'
+          add_message('error', %(
+                      Request #{index + 1}: Token header `typ` field must be set to 'JWT', instead was
+                      #{header['typ']}))
+          next
+        end
+
+        unless header['kid'].present?
+          add_message('error', "Request #{index + 1}: Token header must have the `kid` field")
+          next
+        end
+
         kid = header['kid']
         keys = JSON.parse(crd_jwks_keys[index])
 
         jwk = keys.find { |key| key['kid'] == kid }
-        assert jwk.present?, "JWKS did not contain a public key with an id of `#{kid}`"
+        unless jwk.present?
+          add_message('error', "Request #{index + 1}: JWKS did not contain a public key with an id of `#{kid}`")
+          next
+        end
 
         auth_tokens_jwk_json << jwk.to_json
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
       end
 
       output auth_tokens_jwk_json: auth_tokens_jwk_json.to_json
 
-      error_messages.each do |msg|
-        add_message('error', msg)
-      end
       no_error_validation('Token headers missing required information.')
     end
   end

--- a/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
@@ -12,42 +12,35 @@ module DaVinciCRDTestKit
       that the key used to sign the token can be identified in the JWKS.
     )
 
-    input :auth_tokens_header_json, :crd_jwks_keys_json
+    input :auth_token_headers_json, :crd_jwks_keys_json
     output :auth_tokens_jwk_json
 
     run do
-      auth_token_headers = JSON.parse(auth_tokens_header_json)
+      auth_token_headers = JSON.parse(auth_token_headers_json)
       crd_jwks_keys = JSON.parse(crd_jwks_keys_json)
       skip_if auth_token_headers.empty?, 'No Authorization tokens produced from the previous tests.'
-      skip_if auth_token_headers.empty?, 'No JWKS keys produced from the previous test.'
+      skip_if crd_jwks_keys.empty?, 'No JWKS keys produced from the previous test.'
 
       auth_tokens_jwk_json = []
       auth_token_headers.each_with_index do |token_header, index|
         header = JSON.parse(token_header)
         algorithm = header['alg']
-        unless algorithm.present?
-          add_message('error', "Request #{index + 1}: Token header must have the `alg` field")
-          next
-        end
+
+        add_message('error', "Request #{index + 1}: Token header must have the `alg` field") if algorithm.blank?
 
         if algorithm == 'none'
           add_message('error', "Request #{index + 1}: Token header `alg` field cannot be set to none")
-          next
         end
 
-        unless header['typ'].present?
+        if header['typ'].blank?
           add_message('error', "Request #{index + 1}: Token header must have the `typ` field")
-          next
-        end
-
-        if header['typ'] != 'JWT'
+        elsif header['typ'] != 'JWT'
           add_message('error', %(
                       Request #{index + 1}: Token header `typ` field must be set to 'JWT', instead was
                       #{header['typ']}))
-          next
         end
 
-        unless header['kid'].present?
+        if header['kid'].blank?
           add_message('error', "Request #{index + 1}: Token header must have the `kid` field")
           next
         end
@@ -56,7 +49,7 @@ module DaVinciCRDTestKit
         keys = JSON.parse(crd_jwks_keys[index])
 
         jwk = keys.find { |key| key['kid'] == kid }
-        unless jwk.present?
+        if jwk.blank?
           add_message('error', "Request #{index + 1}: JWKS did not contain a public key with an id of `#{kid}`")
           next
         end

--- a/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
@@ -1,5 +1,9 @@
+require_relative '../client_hook_request_validation'
+
 module DaVinciCRDTestKit
   class TokenHeaderTest < Inferno::Test
+    include ClientHookRequestValidation
+
     id :crd_token_header
     title 'Authorization token header contains required information'
     description %(
@@ -43,9 +47,9 @@ module DaVinciCRDTestKit
       output auth_tokens_jwk_json: auth_tokens_jwk_json.to_json
 
       error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
+        add_message('error', msg)
       end
-      assert error_messages.empty?, 'Token headers missing required information.'
+      no_error_validation('Token headers missing required information.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_header_test.rb
@@ -23,25 +23,25 @@ module DaVinciCRDTestKit
 
       auth_tokens_jwk_json = []
       auth_token_headers.each_with_index do |token_header, index|
+        @request_number = index + 1
+
         header = JSON.parse(token_header)
         algorithm = header['alg']
 
-        add_message('error', "Request #{index + 1}: Token header must have the `alg` field") if algorithm.blank?
+        add_message('error', "#{request_number}Token header must have the `alg` field") if algorithm.blank?
 
-        if algorithm == 'none'
-          add_message('error', "Request #{index + 1}: Token header `alg` field cannot be set to none")
-        end
+        add_message('error', "#{request_number}Token header `alg` field cannot be set to none") if algorithm == 'none'
 
         if header['typ'].blank?
-          add_message('error', "Request #{index + 1}: Token header must have the `typ` field")
+          add_message('error', "#{request_number}Token header must have the `typ` field")
         elsif header['typ'] != 'JWT'
           add_message('error', %(
-                      Request #{index + 1}: Token header `typ` field must be set to 'JWT', instead was
+                      #{request_number}Token header `typ` field must be set to 'JWT', instead was
                       #{header['typ']}))
         end
 
         if header['kid'].blank?
-          add_message('error', "Request #{index + 1}: Token header must have the `kid` field")
+          add_message('error', "#{request_number}Token header must have the `kid` field")
           next
         end
 
@@ -50,7 +50,7 @@ module DaVinciCRDTestKit
 
         jwk = keys.find { |key| key['kid'] == kid }
         if jwk.blank?
-          add_message('error', "Request #{index + 1}: JWKS did not contain a public key with an id of `#{kid}`")
+          add_message('error', "#{request_number}JWKS did not contain a public key with an id of `#{kid}`")
           next
         end
 

--- a/lib/davinci_crd_test_kit/client_tests/token_payload_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_payload_test.rb
@@ -1,5 +1,8 @@
+require_relative '../client_hook_request_validation'
+
 module DaVinciCRDTestKit
   class TokenPayloadTest < Inferno::Test
+    include ClientHookRequestValidation
     include URLs
     id :crd_token_payload
     title 'Authorization token payload has required claims and a valid signature'
@@ -68,9 +71,9 @@ module DaVinciCRDTestKit
       end
 
       error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
+        add_message('error', msg)
       end
-      assert error_messages.empty?, 'Token payload is missing required claims or does not have a valid signiture.'
+      no_error_validation('Token payload is missing required claims or does not have a valid signiture.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client_tests/token_payload_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_payload_test.rb
@@ -39,6 +39,8 @@ module DaVinciCRDTestKit
       skip_if auth_tokens_jwk.empty?, 'No Authorization token JWK produced from the previous test.'
 
       auth_tokens_jwk.each_with_index do |auth_token_jwk, index|
+        @request_number = index + 1
+
         begin
           jwk = JSON.parse(auth_token_jwk).deep_symbolize_keys
 
@@ -58,7 +60,7 @@ module DaVinciCRDTestKit
               verify_aud: true
             )
         rescue StandardError => e
-          add_message('error', "Request #{index + 1}: Token validation error: #{e.message}")
+          add_message('error', "#{request_number}Token validation error: #{e.message}")
           next
         end
 
@@ -66,7 +68,7 @@ module DaVinciCRDTestKit
         missing_claims_string = missing_claims.map { |claim| "`#{claim}`" }.join(', ')
 
         unless missing_claims.empty?
-          add_message('error', "Request #{index + 1}: JWT payload missing required claims: #{missing_claims_string}")
+          add_message('error', "#{request_number}JWT payload missing required claims: #{missing_claims_string}")
           next
         end
       end

--- a/lib/davinci_crd_test_kit/client_tests/token_payload_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/token_payload_test.rb
@@ -25,37 +25,52 @@ module DaVinciCRDTestKit
       base_url + config.options[:hook_path]
     end
 
-    input :auth_token,
-          :auth_token_jwk_json,
+    input :auth_tokens,
+          :auth_tokens_jwk_json,
           :iss
 
     run do
-      begin
-        jwk = JSON.parse(auth_token_jwk_json).deep_symbolize_keys
+      auth_tokens_list = JSON.parse(auth_tokens)
+      auth_tokens_jwk = JSON.parse(auth_tokens_jwk_json)
+      skip_if auth_tokens_list.empty?, 'No Authorization tokens produced from the previous tests.'
+      skip_if auth_tokens_jwk.empty?, 'No Authorization token JWK produced from the previous test.'
 
-        payload, =
-          JWT.decode(
-            auth_token,
-            JWT::JWK.import(jwk).public_key,
-            true,
-            algorithms: [jwk[:alg]],
-            exp_leeway: 60,
-            iss:,
-            aud: hook_url,
-            verify_not_before: false,
-            verify_iat: false,
-            verify_jti: true,
-            verify_iss: true,
-            verify_aud: true
-          )
-      rescue StandardError => e
-        assert false, "Token validation error: #{e.message}"
+      error_messages = []
+      auth_tokens_jwk.each_with_index do |auth_token_jwk, index|
+        begin
+          jwk = JSON.parse(auth_token_jwk).deep_symbolize_keys
+
+          payload, =
+            JWT.decode(
+              auth_tokens_list[index],
+              JWT::JWK.import(jwk).public_key,
+              true,
+              algorithms: [jwk[:alg]],
+              exp_leeway: 60,
+              iss:,
+              aud: hook_url,
+              verify_not_before: false,
+              verify_iat: false,
+              verify_jti: true,
+              verify_iss: true,
+              verify_aud: true
+            )
+        rescue StandardError => e
+          assert false, "Token validation error: #{e.message}"
+        end
+
+        missing_claims = required_claims - payload.keys
+        missing_claims_string = missing_claims.map { |claim| "`#{claim}`" }.join(', ')
+
+        assert missing_claims.empty?, "JWT payload missing required claims: #{missing_claims_string}"
+      rescue Inferno::Exceptions::AssertionException => e
+        error_messages << "Request #{index + 1}: #{e.message}"
       end
 
-      missing_claims = required_claims - payload.keys
-      missing_claims_string = missing_claims.map { |claim| "`#{claim}`" }.join(', ')
-
-      assert missing_claims.empty?, "JWT payload missing required claims: #{missing_claims_string}"
+      error_messages.each do |msg|
+        messages << { type: 'error', message: msg }
+      end
+      assert error_messages.empty?, 'Token payload is missing required claims or does not have a valid signiture.'
     end
   end
 end

--- a/lib/davinci_crd_test_kit/crd_client_suite.rb
+++ b/lib/davinci_crd_test_kit/crd_client_suite.rb
@@ -121,10 +121,6 @@ module DaVinciCRDTestKit
                    }
                  ]
 
-    def self.test_resumes?(test)
-      !test.config.options[:accepts_multiple_requests]
-    end
-
     def self.extract_token_from_query_params(request)
       request.query_parameters['token']
     end

--- a/lib/davinci_crd_test_kit/hook_request_field_validation.rb
+++ b/lib/davinci_crd_test_kit/hook_request_field_validation.rb
@@ -1,5 +1,13 @@
 module DaVinciCRDTestKit
   module HookRequestFieldValidation
+    def request_number_string(request_number = '')
+      @request_number_string ||= if request_number.blank?
+                                   ''
+                                 else
+                                   "Request #{request_number}: "
+                                 end
+    end
+
     def hook_required_fields
       {
         'hook' => String,
@@ -82,7 +90,10 @@ module DaVinciCRDTestKit
         'Medication' => 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication',
         'Device' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-device',
         'CommunicationRequest' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-communicationrequest',
-        'Task' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-taskquestionnaire'
+        'Task' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-taskquestionnaire',
+        'Coverage' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-coverage',
+        'Location' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-location',
+        'Organization' => 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-organization'
       }.freeze
     end
 
@@ -101,7 +112,9 @@ module DaVinciCRDTestKit
              'Missing `fhirServer` field: If `fhirAuthorization` is provided, this field is REQUIRED.')
     end
 
-    def hook_request_fhir_auth_check(request_body)
+    def hook_request_fhir_auth_check(request_body, request_number = '')
+      @request_number_string = nil
+      request_number_string(request_number)
       if request_body['fhirAuthorization']
 
         fhir_authorization = request_body['fhirAuthorization']
@@ -121,24 +134,27 @@ module DaVinciCRDTestKit
         if scopes.any? { |scope| scope.start_with?('patient/') }
           info do
             assert(fhir_authorization['patient'] && fhir_authorization['patient'].is_a?(String),
-                   %(The `patient` field SHOULD be populated to identify the FHIR id of that patient when the granted
-                    SMART scopes include patient scopes))
+                   %(#{request_number_string}The `patient` field for request SHOULD be populated to identify the FHIR id
+                   of that patient when the granted SMART scopes include patient scopes))
           end
         end
       end
       { fhir_server_uri: request_body['fhirServer'], fhir_access_token: access_token }
     end
 
-    def hook_request_optional_fields_check(request_body)
+    def hook_request_optional_fields_check(request_body, request_number = '')
+      @request_number_string = nil
+      request_number_string(request_number)
       hook_optional_fields.each do |field, type|
         info do
-          assert(request_body[field], "Hook request did not contain optional field: `#{field}`")
+          assert(request_body[field], "#{request_number_string}Hook request did not contain optional field: `#{field}`")
         end
         if request_body[field]
-          assert(request_body[field].is_a?(type), "Hook request field #{field} is not of type #{type}")
+          assert(request_body[field].is_a?(type),
+                 "Hook request field #{field} is not of type #{type}")
         end
       end
-      hook_request_fhir_auth_check(request_body)
+      hook_request_fhir_auth_check(request_body, request_number)
     end
 
     def validate_presence_and_type(object, field_name, type, description = '')
@@ -162,10 +178,13 @@ module DaVinciCRDTestKit
       add_message('error', error_msg)
     end
 
-    def hook_request_context_check(context, hook_name)
+    def hook_request_context_check(context, hook_name, request_number = '')
+      @request_number_string = nil
+      request_number_string(request_number)
       required_fields = context_required_fields_by_hook[hook_name]
       required_fields.each do |field, type|
-        validate_presence_and_type(context, field, type, "#{hook_name} request context")
+        validate_presence_and_type(context, field, type,
+                                   "#{request_number_string}#{hook_name} request context")
       end
       context_validate_optional_fields(context, hook_name)
       hook_specific_context_check(context, hook_name)
@@ -195,7 +214,7 @@ module DaVinciCRDTestKit
       resource_type, resource_id = reference.split('/')
 
       if supported_resource_types && !supported_resource_types.include?(resource_type)
-        error_msg = "Unsupported resource type: `#{field_name}` type should be one " \
+        error_msg = "#{request_number_string}Unsupported resource type: `#{field_name}` type should be one " \
                     "of the following: #{supported_resource_types.to_sentence}, but " \
                     "received #{resource_type}."
 
@@ -210,7 +229,10 @@ module DaVinciCRDTestKit
       resource_type, resource_id = reference.split('/')
       return true if resource_type.present? && resource_id.present?
 
-      add_message('error', "Invalid `#{field_name}` format. Expected `{resourceType}/{id}`, received `#{reference}`.")
+      add_message('error', %(
+        #{request_number_string}Invalid `#{field_name}` format. Expected `{resourceType}/{id}`,
+        received `#{reference}`.
+      ))
       false
     end
 
@@ -228,7 +250,9 @@ module DaVinciCRDTestKit
 
     def valid_id_format?(field, hook_name, resource_id)
       if resource_id.include?('/')
-        error_msg = "`#{field}` in #{hook_name} context should be a plain ID, not a reference. Got: `#{resource_id}`."
+        error_msg = %(
+          #{request_number_string}`#{field}` in #{hook_name} context should be a plain ID, not a reference.
+          Got: `#{resource_id}`.)
         add_message('error', error_msg)
         false
       end
@@ -238,8 +262,8 @@ module DaVinciCRDTestKit
     def bundle_entries_check(context, context_field_name, bundle, resource_types, status = nil)
       target_resources = bundle.entry.map(&:resource).select { |r| resource_types.include?(r.resourceType) }
       unless target_resources.present?
-        error_msg = "`#{context_field_name}` bundle must contain at least one of the expected resource types: " \
-                    "#{resource_types.to_sentence}. In Context `#{context}`"
+        error_msg = "#{request_number_string}`#{context_field_name}` bundle must contain at least one of the " \
+                    "expected resource types: #{resource_types.to_sentence}. In Context `#{context}`"
         add_message('error', error_msg)
         return
       end
@@ -254,24 +278,24 @@ module DaVinciCRDTestKit
     def status_check(context, context_field_name, status, resources)
       return unless status && !resources.all? { |resource| resource.status == status }
 
-      error_msg = "All #{resources.map(&:resourceType).uniq.to_sentence} resources in `#{context_field_name}` " \
-                  "bundle must have a `#{status}` status. In Context `#{context}`"
+      error_msg = "#{request_number_string}All #{resources.map(&:resourceType).uniq.to_sentence} resources in " \
+                  "`#{context_field_name}` bundle must have a `#{status}` status. In Context `#{context}`"
       add_message('error', error_msg)
     end
 
     def parse_fhir_bundle_from_context(context_field_name, context)
       fhir_bundle = FHIR.from_contents(context[context_field_name].to_json)
       unless fhir_bundle
-        error_msg = "`#{context_field_name}` field is not a FHIR resource: `#{context[context_field_name]}`. " \
-                    "In Context `#{context}`"
+        error_msg = "#{request_number_string}`#{context_field_name}` field is not a FHIR resource: " \
+                    "`#{context[context_field_name]}`. In Context `#{context}`"
         add_message('error', error_msg)
         return
       end
 
       return fhir_bundle if fhir_bundle.is_a?(FHIR::Bundle)
 
-      error_msg = "Wrong context resource type: Expected `Bundle`, got `#{fhir_bundle.resourceType}`. " \
-                  "In Context `#{context}`"
+      error_msg = "#{request_number_string}Wrong context resource type: Expected `Bundle`, got " \
+                  "`#{fhir_bundle.resourceType}`. In Context `#{context}`"
       add_message('error', error_msg)
       nil
     end
@@ -283,7 +307,7 @@ module DaVinciCRDTestKit
         resource_reference_check(reference, 'selections item', supported_resource_types: expected_resource_types)
         next if order_refs.include?(reference)
 
-        error_msg = '`selections` field must reference FHIR resources in `draftOrders`. ' \
+        error_msg = "#{request_number_string}`selections` field must reference FHIR resources in `draftOrders`. " \
                     "#{reference} is not in `draftOrders`. In Context `#{context}`"
         add_message('error', error_msg)
       end
@@ -352,15 +376,20 @@ module DaVinciCRDTestKit
       fhir_read(resource_type, resource_id)
       status = request.response[:status]
       unless status == 200
-        add_message('error', "Unexpected response status: expected 200, but received #{status}")
+        add_message('error', "#{request_number_string}Unexpected response status: expected 200, but received #{status}")
         return
       end
       unless resource.resourceType == resource_type
-        add_message('error', "Unexpected resource type: Expected `#{resource_type}`. Got `#{resource.resourceType}`.")
+        add_message('error', %(
+          #{request_number_string}Unexpected resource type: Expected `#{resource_type}`. Got
+          `#{resource.resourceType}`.
+        ))
         return
       end
       unless resource.id == resource_id
-        add_message('error', "Requested resource with id #{resource_id}, received resource with id #{resource.id}")
+        add_message('error', %(
+          #{request_number_string}Requested resource with id #{resource_id}, received resource with id #{resource.id}
+          ))
         return
       end
 
@@ -395,16 +424,105 @@ module DaVinciCRDTestKit
         resource_json = entry.to_json
         fhir_resource = FHIR.from_contents(resource_json)
         unless fhir_resource
-          add_message('error', "Field `#{field}` is not a FHIR resource.")
+          add_message('error', "#{request_number_string}Field `#{field}` is not a FHIR resource.")
           next
         end
         resource_type = optional_field_resource_types[field]
         unless fhir_resource.resourceType == resource_type
-          add_message('error', "Field `#{field}` must be a `#{resource_type}`. Got `#{fhir_resource.resourceType}`.")
+          add_message('error', %(
+            #{request_number_string}Field `#{field}` must be a `#{resource_type}`. Got
+            `#{fhir_resource.resourceType}`.
+          ))
           next
         end
         resource_is_valid?(resource: fhir_resource)
       end
+    end
+
+    def hook_request_prefetch_check(advertised_prefetch_fields, received_prefetch, received_context)
+      advertised_prefetch_fields.each do |advertised_prefetch_key, advertised_prefetch_template|
+        next unless received_prefetch[advertised_prefetch_key].present?
+
+        assert(received_prefetch[advertised_prefetch_key].is_a?(Hash),
+               "Prefetch field `#{advertised_prefetch_key}` is not of type `Hash`.")
+
+        received_prefetch_resource = FHIR.from_contents(received_prefetch[advertised_prefetch_key].to_json)
+
+        if advertised_prefetch_template.include?('?')
+          advertised_prefetch_fhir_search = advertised_prefetch_template.gsub(/{|}/, '').split('?')
+          advertised_prefetch_resource_type = advertised_prefetch_fhir_search.first
+
+          if advertised_prefetch_resource_type == 'Coverage'
+            advertised_coverage_query_params = Rack::Utils.parse_nested_query(advertised_prefetch_fhir_search.last)
+
+            advertised_patient_token = advertised_coverage_query_params['patient']
+            advertised_context_patient_id_key = advertised_patient_token.split('.').last
+            received_context_patient_id = received_context[advertised_context_patient_id_key]
+
+            advertised_status_param = advertised_coverage_query_params['status']
+
+            validate_prefetch_coverage(received_prefetch_resource, advertised_prefetch_key, received_context_patient_id,
+                                       advertised_status_param)
+          end
+        else
+          advertised_prefetch_token = advertised_prefetch_template.gsub(/{|}/, '').split('/')
+          advertised_context_id = advertised_prefetch_token.last.split('.').last
+
+          if advertised_prefetch_token.length == 1
+            received_context_reference = FHIR::Reference.new(reference: received_context[advertised_context_id])
+            received_context_resource_type = received_context_reference.resource_type
+            received_context_id = received_context_reference.reference_id
+          else
+            received_context_id = received_context[advertised_context_id]
+            received_context_resource_type = advertised_prefetch_token.first
+          end
+          validate_prefetch_resource(received_prefetch_resource, advertised_prefetch_key,
+                                     received_context_resource_type, received_context_id)
+        end
+      end
+    end
+
+    def validate_prefetch_coverage(received_resource, advertised_prefetch_key,
+                                   received_context_patient_id, advertised_status)
+      assert_resource_type('Bundle', resource: received_resource)
+      assert(received_resource.entry.any?, 'Bundle of coverage resources received from prefetch is empty')
+      coverage_resource = received_resource.entry.first.resource
+      assert_resource_type('Coverage', resource: coverage_resource)
+      resource_is_valid?(resource: coverage_resource,
+                         profile_url: structure_definition_map['Coverage'])
+
+      coverage_beneficiary_reference = coverage_resource.beneficiary
+      coverage_beneficiary_patient_id = coverage_beneficiary_reference.reference_id
+      assert(coverage_beneficiary_patient_id.present?,
+             "Could not get beneficiary reference id from `#{advertised_prefetch_key}` field's Coverage resource")
+
+      assert(coverage_beneficiary_patient_id == received_context_patient_id,
+             %(Expected `#{advertised_prefetch_key}` field's Coverage resource to have a `beneficiary` reference id of
+                '#{received_context_patient_id}', instead was '#{coverage_beneficiary_patient_id}'))
+
+      coverage_status = coverage_resource.status
+      assert(coverage_status == advertised_status,
+             %(Expected `#{advertised_prefetch_key}` field's Coverage resource to have a `status` of
+                '#{advertised_status}', instead was '#{coverage_status}'))
+    end
+
+    def validate_prefetch_resource(received_resource, advertised_prefetch_key, context_field_resource_type,
+                                   context_field_id)
+      assert_resource_type(context_field_resource_type, resource: received_resource)
+
+      if hook_name == 'order-dispatch'
+        resource_is_valid?(resource: received_resource)
+      else
+        resource_is_valid?(resource: received_resource,
+                           profile_url: structure_definition_map[context_field_resource_type])
+      end
+
+      received_prefetch_resource_id = received_resource.id
+      assert(received_prefetch_resource_id.present?,
+             "`#{advertised_prefetch_key}` field's FHIR resource does not contain the `id` field")
+      assert(received_prefetch_resource_id == context_field_id,
+             %(Expected `#{advertised_prefetch_key}` field's FHIR resource to have an `id` of '#{context_field_id}',
+              instead was '#{received_prefetch_resource_id}'))
     end
   end
 end

--- a/lib/davinci_crd_test_kit/mock_service_response.rb
+++ b/lib/davinci_crd_test_kit/mock_service_response.rb
@@ -177,7 +177,7 @@ module DaVinciCRDTestKit
     def get_context_resource(request_body, resource_type, update_resource_id)
       update_resource_id = "#{resource_type}/#{update_resource_id}" unless update_resource_id.include? '/'
       fhir_server = request_body['fhirServer']
-      return unless fhir_server.present?
+      return if fhir_server.blank?
 
       access_token = request_body['fhirAuthorization']['access_token'] if request_body['fhirAuthorization']
       make_resource_request(

--- a/lib/davinci_crd_test_kit/routes/hook_request_endpoint.rb
+++ b/lib/davinci_crd_test_kit/routes/hook_request_endpoint.rb
@@ -31,6 +31,10 @@ module DaVinciCRDTestKit
       end
     end
 
+    def resume_test_run?
+      find_result&.result != 'wait'
+    end
+
     # Header expected to be a bearer token of the form "Bearer <token>"
     def extract_bearer_token(request)
       request.headers['authorization']&.delete_prefix('Bearer ')
@@ -87,7 +91,7 @@ module DaVinciCRDTestKit
     end
 
     def update_result
-      results_repo.update(result.id, result: 'pass')
+      results_repo.update(result.id, result: 'pass') unless test.config.options[:accepts_multiple_requests]
     end
   end
 end

--- a/lib/davinci_crd_test_kit/routes/hook_request_endpoint.rb
+++ b/lib/davinci_crd_test_kit/routes/hook_request_endpoint.rb
@@ -31,10 +31,6 @@ module DaVinciCRDTestKit
       end
     end
 
-    def resume_test_run?
-      find_result&.result != 'wait'
-    end
-
     # Header expected to be a bearer token of the form "Bearer <token>"
     def extract_bearer_token(request)
       request.headers['authorization']&.delete_prefix('Bearer ')
@@ -88,10 +84,6 @@ module DaVinciCRDTestKit
 
     def name
       extract_hook_name(request).gsub('-', '_')
-    end
-
-    def update_result
-      results_repo.update(result.id, result: 'pass') unless test.config.options[:accepts_multiple_requests]
     end
   end
 end

--- a/lib/davinci_crd_test_kit/server_tests/service_request_optional_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server_tests/service_request_optional_fields_validation_test.rb
@@ -24,10 +24,11 @@ module DaVinciCRDTestKit
       skip_if requests.empty?, "No #{hook_name} request was made in a previous test as expected."
 
       requests.each_with_index do |request, index|
-        request_body = json_parse(request.request_body, index + 1)
-        next unless request_body
+        @request_number = index + 1
+        request_body = json_parse(request.request_body)
+        next if request_body.blank?
 
-        hook_request_optional_fields_check(request_body, index + 1)
+        hook_request_optional_fields_check(request_body)
       end
       no_error_validation('Some service requests have invalid optional fields.')
     end

--- a/lib/davinci_crd_test_kit/server_tests/service_request_optional_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server_tests/service_request_optional_fields_validation_test.rb
@@ -23,19 +23,13 @@ module DaVinciCRDTestKit
       load_tagged_requests(hook_name)
       skip_if requests.empty?, "No #{hook_name} request was made in a previous test as expected."
 
-      error_messages = []
       requests.each_with_index do |request, index|
-        assert_valid_json(request.request_body)
-        request_body = JSON.parse(request.request_body)
-        hook_request_optional_fields_check(request_body)
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
-      end
+        request_body = json_parse(request.request_body, index + 1)
+        next unless request_body
 
-      error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
+        hook_request_optional_fields_check(request_body, index + 1)
       end
-      assert error_messages.empty?, 'Some service requests have invalid optional fields.'
+      no_error_validation('Some service requests have invalid optional fields.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/server_tests/service_request_optional_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server_tests/service_request_optional_fields_validation_test.rb
@@ -26,7 +26,10 @@ module DaVinciCRDTestKit
       requests.each_with_index do |request, index|
         @request_number = index + 1
         request_body = json_parse(request.request_body)
-        next if request_body.blank?
+        if request_body.blank?
+          add_message('error', "#{request_number}Hook request body cannot be empty.")
+          next
+        end
 
         hook_request_optional_fields_check(request_body)
       end

--- a/lib/davinci_crd_test_kit/server_tests/service_request_required_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server_tests/service_request_required_fields_validation_test.rb
@@ -22,11 +22,12 @@ module DaVinciCRDTestKit
       skip_if requests.empty?, "No #{hook_name} request was made in a previous test as expected."
       contexts = []
       requests.each_with_index do |request, index|
-        request_body = json_parse(request.request_body, index + 1)
-        next unless request_body
+        @request_number = index + 1
+        request_body = json_parse(request.request_body)
+        next if request_body.blank?
 
         contexts << request_body['context'] if request_body['context'].is_a?(Hash)
-        hook_request_required_fields_check(request_body, hook_name, index + 1)
+        hook_request_required_fields_check(request_body, hook_name)
       end
 
       output contexts: contexts.to_json

--- a/lib/davinci_crd_test_kit/server_tests/service_request_required_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server_tests/service_request_required_fields_validation_test.rb
@@ -20,24 +20,18 @@ module DaVinciCRDTestKit
     run do
       load_tagged_requests(hook_name)
       skip_if requests.empty?, "No #{hook_name} request was made in a previous test as expected."
-
-      error_messages = []
       contexts = []
       requests.each_with_index do |request, index|
-        assert_valid_json(request.request_body)
-        request_body = JSON.parse(request.request_body)
+        request_body = json_parse(request.request_body, index + 1)
+        next unless request_body
+
         contexts << request_body['context'] if request_body['context'].is_a?(Hash)
-        hook_request_required_fields_check(request_body, hook_name)
-      rescue Inferno::Exceptions::AssertionException => e
-        error_messages << "Request #{index + 1}: #{e.message}"
+        hook_request_required_fields_check(request_body, hook_name, index + 1)
       end
 
       output contexts: contexts.to_json
 
-      error_messages.each do |msg|
-        messages << { type: 'error', message: msg }
-      end
-      assert error_messages.empty?, 'Some service requests made are not valid.'
+      no_error_validation('Some service requests made are not valid.')
     end
   end
 end

--- a/lib/davinci_crd_test_kit/tags.rb
+++ b/lib/davinci_crd_test_kit/tags.rb
@@ -1,8 +1,8 @@
 module DaVinciCRDTestKit
-  APPOINTMENT_BOOK_TAG = 'crd_appointment_book'.freeze
-  ENCOUNTER_START_TAG = 'crd_encounter_start'.freeze
-  ENCOUNTER_DISCHARGE_TAG = 'crd_encounter_discharge'.freeze
-  ORDER_DISPATCH_TAG = 'crd_order_dispatch'.freeze
-  ORDER_SELECT_TAG = 'crd_order_select'.freeze
-  ORDER_SIGN_TAG = 'crd_order_sign'.freeze
+  APPOINTMENT_BOOK_TAG = 'appointment-book'.freeze
+  ENCOUNTER_START_TAG = 'encounter-start'.freeze
+  ENCOUNTER_DISCHARGE_TAG = 'encounter-discharge'.freeze
+  ORDER_DISPATCH_TAG = 'order-dispatch'.freeze
+  ORDER_SELECT_TAG = 'order-select'.freeze
+  ORDER_SIGN_TAG = 'order-sign'.freeze
 end

--- a/spec/davinci_crd_test_kit/appointment_book_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/appointment_book_receive_request_test_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DaVinciCRDTestKit::AppointmentBookReceiveRequestTest do
 
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:test) { Inferno::Repositories::Tests.new.find('crd_appointment_book_request') }
+  let(:test_group) { Inferno::Repositories::TestGroups.new.find('crd_client_hooks') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
@@ -64,7 +65,7 @@ RSpec.describe DaVinciCRDTestKit::AppointmentBookReceiveRequestTest do
   end
 
   it 'passes and responds 200 if request sent to the provided URL and jwt `iss` claim matches the given`iss`' do
-    allow(test).to receive(:suite).and_return(suite)
+    allow(test).to receive_messages(suite:, parent: test_group)
 
     token = jwt_helper.build(
       aud: appointment_book_url,

--- a/spec/davinci_crd_test_kit/appointment_book_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/appointment_book_receive_request_test_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe DaVinciCRDTestKit::AppointmentBookReceiveRequestTest do
 
   let(:example_client_url) { 'https://cds.example.org' }
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
+  let(:resume_pass_url) do
+    "#{Inferno::Application['base_url']}/custom/crd_client/resume_pass?token=appointment-book%20#{example_client_url}"
+  end
   let(:appointment_book_url) { "#{base_url}/cds-services/appointment-book-service" }
   let(:client_fhir_server) { 'https://example/r4' }
   let(:patient_id) { 'example' }
@@ -48,6 +51,7 @@ RSpec.describe DaVinciCRDTestKit::AppointmentBookReceiveRequestTest do
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+
     inputs.each do |name, value|
       session_data_repo.save(
         test_session_id: test_session.id,
@@ -76,8 +80,8 @@ RSpec.describe DaVinciCRDTestKit::AppointmentBookReceiveRequestTest do
     body['prefetch'] = { 'coverage' => crd_coverage }
     header('Authorization', "Bearer #{token}")
     post_json(server_endpoint, body)
-
     expect(last_response).to be_ok
+    get(resume_pass_url)
     result = results_repo.find(result.id)
     expect(result.result).to eq('pass')
   end

--- a/spec/davinci_crd_test_kit/decode_auth_token_test_spec.rb
+++ b/spec/davinci_crd_test_kit/decode_auth_token_test_spec.rb
@@ -118,14 +118,6 @@ RSpec.describe DaVinciCRDTestKit::DecodeAuthTokenTest do
       )
     end
 
-    it 'skips if no authorization header included in request' do
-      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: nil)
-
-      result = run(test)
-      expect(result.result).to eq('skip')
-      expect(result.result_message).to eq('No appointment-book requests contained the Authorization header')
-    end
-
     it 'fails if authorization header does not present the JWT as a `Bearer` token' do
       token = jwt_helper.build(
         aud: appointment_book_url,

--- a/spec/davinci_crd_test_kit/decode_auth_token_test_spec.rb
+++ b/spec/davinci_crd_test_kit/decode_auth_token_test_spec.rb
@@ -4,8 +4,10 @@ require_relative '../../lib/davinci_crd_test_kit/jwt_helper'
 RSpec.describe DaVinciCRDTestKit::DecodeAuthTokenTest do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
-  let(:test) { Inferno::Repositories::Tests.new.find('crd_decode_auth_token') }
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:runnable) { Inferno::Repositories::Tests.new.find('crd_decode_auth_token') }
 
   let(:example_client_url) { 'https://cds.example.org' }
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
@@ -41,50 +43,102 @@ RSpec.describe DaVinciCRDTestKit::DecodeAuthTokenTest do
     ]
     repo_create(
       :request,
-      name: 'hook_request',
+      name: 'appointment_book',
       direction: 'incoming',
       url: 'http://example.com/custom/crd_client/cds-services/appointment-book-service',
       test_session_id: test_session.id,
       request_body: body.is_a?(Hash) ? body.to_json : body,
+      result:,
       status:,
-      headers:
+      headers:,
+      tags: ['appointment-book']
     )
   end
 
-  it 'passes if valid authorization header included in request' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
-
-    create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
-
-    result = run(test)
-    expect(result.result).to eq('pass')
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+      .first
   end
 
-  it 'skips if no authorization header included in request' do
-    create_appointment_hook_request(body: appointment_book_hook_request, auth_header: nil)
+  describe 'Appointment Book Decode Auth Token Test' do
+    let(:test) do
+      Class.new(DaVinciCRDTestKit::DecodeAuthTokenTest) do
+        config(
+          options: { hook_name: 'appointment-book' }
+        )
+      end
+    end
 
-    result = run(test)
-    expect(result.result).to eq('skip')
-    expect(result.result_message).to eq('Request does not include an Authorization header')
-  end
+    it 'passes if valid authorization header included in request' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'fails if authorization header does not present the JWT as a `Bearer` token' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: appointment_book_hook_request, auth_header: token)
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
 
-    result = run(test)
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('Authorization token must be a JWT presented as a `Bearer` token')
+    it 'passes if multiple requests have valid authorization headers' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if one of many requests has an invalid authorization headers' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: token)
+
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(
+        /Request 2: Authorization token must be a JWT presented as a `Bearer` token/
+      )
+    end
+
+    it 'skips if no authorization header included in request' do
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: nil)
+
+      result = run(test)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to eq('No appointment-book requests contained the Authorization header')
+    end
+
+    it 'fails if authorization header does not present the JWT as a `Bearer` token' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: token)
+
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/Authorization token must be a JWT presented as a `Bearer` token/)
+    end
   end
 end

--- a/spec/davinci_crd_test_kit/encounter_discharge_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/encounter_discharge_receive_request_test_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DaVinciCRDTestKit::EncounterDischargeReceiveRequestTest do
 
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:test) { Inferno::Repositories::Tests.new.find('crd_encounter_discharge_request') }
+  let(:test_group) { Inferno::Repositories::TestGroups.new.find('crd_client_hooks') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
@@ -64,7 +65,7 @@ RSpec.describe DaVinciCRDTestKit::EncounterDischargeReceiveRequestTest do
   end
 
   it 'passes and responds 200 if request sent to the provided URL and jwt `iss` claim matches the given`iss`' do
-    allow(test).to receive(:suite).and_return(suite)
+    allow(test).to receive_messages(suite:, parent: test_group)
 
     token = jwt_helper.build(
       aud: encounter_discharge_url,

--- a/spec/davinci_crd_test_kit/encounter_discharge_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/encounter_discharge_receive_request_test_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe DaVinciCRDTestKit::EncounterDischargeReceiveRequestTest do
 
   let(:example_client_url) { 'https://cds.example.org' }
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
+  let(:resume_pass_url) do
+    "#{Inferno::Application['base_url']}/custom/crd_client/resume_pass" \
+      "?token=encounter-discharge%20#{example_client_url}"
+  end
   let(:encounter_discharge_url) { "#{base_url}/cds-services/encounter-discharge-service" }
   let(:client_fhir_server) { 'https://example/r4' }
   let(:patient_id) { 'example' }
@@ -76,8 +80,9 @@ RSpec.describe DaVinciCRDTestKit::EncounterDischargeReceiveRequestTest do
     body['prefetch'] = { 'coverage' => crd_coverage, 'encounter' => crd_encounter }
     header('Authorization', "Bearer #{token}")
     post_json(server_endpoint, body)
-
     expect(last_response).to be_ok
+    get(resume_pass_url)
+
     result = results_repo.find(result.id)
     expect(result.result).to eq('pass')
   end

--- a/spec/davinci_crd_test_kit/encounter_start_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/encounter_start_receive_request_test_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe DaVinciCRDTestKit::EncounterStartReceiveRequestTest do
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
 
   let(:example_client_url) { 'https://cds.example.org' }
+  let(:resume_pass_url) do
+    "#{Inferno::Application['base_url']}/custom/crd_client/resume_pass?token=encounter-start%20#{example_client_url}"
+  end
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
   let(:encounter_start_url) { "#{base_url}/cds-services/encounter-start-service" }
   let(:client_fhir_server) { 'https://example/r4' }
@@ -77,6 +80,8 @@ RSpec.describe DaVinciCRDTestKit::EncounterStartReceiveRequestTest do
     header('Authorization', "Bearer #{token}")
     post_json(server_endpoint, body)
     expect(last_response).to be_ok
+    get(resume_pass_url)
+
     result = results_repo.find(result.id)
     expect(result.result).to eq('pass')
   end

--- a/spec/davinci_crd_test_kit/encounter_start_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/encounter_start_receive_request_test_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DaVinciCRDTestKit::EncounterStartReceiveRequestTest do
 
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:test) { Inferno::Repositories::Tests.new.find('crd_encounter_start_request') }
+  let(:test_group) { Inferno::Repositories::TestGroups.new.find('crd_client_hooks') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
@@ -63,7 +64,7 @@ RSpec.describe DaVinciCRDTestKit::EncounterStartReceiveRequestTest do
   end
 
   it 'passes and responds 200 if request sent to the provided URL and jwt `iss` claim matches the given`iss`' do
-    allow(test).to receive(:suite).and_return(suite)
+    allow(test).to receive_messages(suite:, parent: test_group)
 
     token = jwt_helper.build(
       aud: encounter_start_url,

--- a/spec/davinci_crd_test_kit/hook_request_optional_fields_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_optional_fields_test_spec.rb
@@ -3,9 +3,11 @@ require_relative '../../lib/davinci_crd_test_kit/jwt_helper'
 
 RSpec.describe DaVinciCRDTestKit::HookRequestOptionalFieldsTest do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:runnable) { Inferno::Repositories::Tests.new.find('crd_hook_request_optional_fields') }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
-  let(:test) { Inferno::Repositories::Tests.new.find('crd_hook_request_optional_fields') }
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
 
   let(:example_client_url) { 'https://cds.example.org' }
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
@@ -47,189 +49,261 @@ RSpec.describe DaVinciCRDTestKit::HookRequestOptionalFieldsTest do
       name: 'hook_request',
       direction: 'incoming',
       url:,
+      result:,
       test_session_id: test_session.id,
       request_body: body.is_a?(Hash) ? body.to_json : body,
       status:,
-      headers:
+      headers:,
+      tags: ['appointment-book']
     )
   end
 
-  it 'passes without all optional fields and produces output if it contains `fhirAuthorization` field' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+  def entity_result_message(index: 0)
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages[index]
+  end
 
-    create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
-
-    result = run(test)
-    expect(result.result).to eq('pass')
-
-    outputs_hash = JSON.parse(result.output_json)
-
-    fhir_server_output = outputs_hash.any? do |output|
-      output['name'] == 'client_fhir_server' && output['value'] == client_fhir_server_output
+  describe 'Appointment Book Hook Request Optional Fields' do
+    let(:test) do
+      Class.new(DaVinciCRDTestKit::HookRequestOptionalFieldsTest) do
+        config(
+          options: { hook_name: 'appointment-book' }
+        )
+      end
     end
 
-    access_token_output = outputs_hash.any? do |output|
-      output['name'] == 'client_access_token' && output['value'] == client_access_token_output
+    it 'passes without all optional fields and produces output if it contains `fhirAuthorization` field' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+
+      result = run(test)
+      expect(result.result).to eq('pass')
+
+      outputs_hash = JSON.parse(result.output_json)
+
+      fhir_server_output = outputs_hash.any? do |output|
+        output['name'] == 'client_fhir_server' && output['value'] == client_fhir_server_output
+      end
+
+      access_token_output = outputs_hash.any? do |output|
+        output['name'] == 'client_access_token' && output['value'] == client_access_token_output
+      end
+
+      expect(fhir_server_output).to be true
+      expect(access_token_output).to be true
     end
 
-    expect(fhir_server_output).to be true
-    expect(access_token_output).to be true
-  end
+    it 'passes with multiple requests' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'passes and produces fhir server but not bearer token output when no `fhirAuthorization` field' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
 
-    hook_request_no_fhir_auth = appointment_book_hook_request_hash.except('fhirAuthorization')
+      result = run(test)
+      expect(result.result).to eq('pass')
 
-    create_appointment_hook_request(body: hook_request_no_fhir_auth, auth_header: "Bearer #{token}")
+      outputs_hash = JSON.parse(result.output_json)
 
-    result = run(test)
-    expect(result.result).to eq('pass')
+      fhir_server_output = outputs_hash.any? do |output|
+        output['name'] == 'client_fhir_server' && output['value'] == client_fhir_server_output
+      end
 
-    outputs_hash = JSON.parse(result.output_json)
+      access_token_output = outputs_hash.any? do |output|
+        output['name'] == 'client_access_token' && output['value'] == client_access_token_output
+      end
 
-    fhir_server_output = outputs_hash.any? do |output|
-      output['name'] == 'client_fhir_server' && output['value'] == client_fhir_server_output
+      expect(fhir_server_output).to be true
+      expect(access_token_output).to be true
     end
 
-    access_token_output = outputs_hash.any? do |output|
-      output['name'] == 'client_access_token' && output['value'].blank?
+    it 'fails if one of multiple requests are invalid' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+
+      invalid_hook_request = appointment_book_hook_request_hash
+      invalid_hook_request['fhirAuthorization'] = invalid_hook_request['fhirAuthorization'].except('access_token')
+
+      create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
+
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message(index: 2).message).to match(
+        /Request 2: `fhirAuthorization` did not contain required field: `access_token`/
+      )
     end
 
-    expect(fhir_server_output).to be true
-    expect(access_token_output).to be true
-  end
+    it 'passes and produces fhir server but not bearer token output when no `fhirAuthorization` field' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'passes and produces no output when no `fhirServer` or `fhirAuthorization` field' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      hook_request_no_fhir_auth = appointment_book_hook_request_hash.except('fhirAuthorization')
 
-    hook_request_no_fhir_auth = appointment_book_hook_request_hash
-      .except('fhirAuthorization')
-      .except('fhirServer')
+      create_appointment_hook_request(body: hook_request_no_fhir_auth, auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: hook_request_no_fhir_auth, auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('pass')
 
-    result = run(test)
-    expect(result.result).to eq('pass')
+      outputs_hash = JSON.parse(result.output_json)
 
-    outputs_hash = JSON.parse(result.output_json)
+      fhir_server_output = outputs_hash.any? do |output|
+        output['name'] == 'client_fhir_server' && output['value'] == client_fhir_server_output
+      end
 
-    fhir_server_output = outputs_hash.any? do |output|
-      output['name'] == 'client_fhir_server' && output['value'].blank?
+      access_token_output = outputs_hash.any? do |output|
+        output['name'] == 'client_access_token' && output['value'].blank?
+      end
+
+      expect(fhir_server_output).to be true
+      expect(access_token_output).to be true
     end
 
-    access_token_output = outputs_hash.any? do |output|
-      output['name'] == 'client_access_token' && output['value'].blank?
+    it 'passes and produces no output when no `fhirServer` or `fhirAuthorization` field' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      hook_request_no_fhir_auth = appointment_book_hook_request_hash
+        .except('fhirAuthorization')
+        .except('fhirServer')
+
+      create_appointment_hook_request(body: hook_request_no_fhir_auth, auth_header: "Bearer #{token}")
+
+      result = run(test)
+      expect(result.result).to eq('pass')
+
+      outputs_hash = JSON.parse(result.output_json)
+
+      fhir_server_output = outputs_hash.any? do |output|
+        output['name'] == 'client_fhir_server' && output['value'].blank?
+      end
+
+      access_token_output = outputs_hash.any? do |output|
+        output['name'] == 'client_access_token' && output['value'].blank?
+      end
+
+      expect(fhir_server_output).to be true
+      expect(access_token_output).to be true
     end
 
-    expect(fhir_server_output).to be true
-    expect(access_token_output).to be true
-  end
+    it 'skips if no appointment-book request can be found' do
+      result = run(test)
+      expect(result.result).to eq('skip')
+      expect(result.result_message).to eq('No appointment-book requests were made in a previous test as expected.')
+    end
 
-  it 'skips if no appointment-book request can be found' do
-    result = run(test)
-    expect(result.result).to eq('skip')
-    expect(result.result_message).to eq('Request `hook_request` was not made in a previous test as expected.')
-  end
+    it 'fails if hook request body is not a valid json' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'fails if hook request body is not a valid json' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      create_appointment_hook_request(body: 'request_body', auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: 'request_body', auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/Request 1: Invalid JSON./)
+    end
 
-    result = run(test)
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('Invalid JSON. ')
-  end
+    it 'fails if an optional field is not of the correct type' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'fails if an optional field is not of the correct type' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      invalid_hook_request = appointment_book_hook_request_hash
+      invalid_hook_request['prefetch'] = 'Prefetch String'
 
-    invalid_hook_request = appointment_book_hook_request_hash
-    invalid_hook_request['prefetch'] = 'Prefetch String'
+      create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/Request 1: Hook request field prefetch is not of type Hash/)
+    end
 
-    result = run(test)
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('Hook request field prefetch is not of type Hash')
-  end
+    it 'fails if hook request missing required field in fhirAuthorization' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'fails if hook request missing required field in fhirAuthorization' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      invalid_hook_request = appointment_book_hook_request_hash
+      invalid_hook_request['fhirAuthorization'] = invalid_hook_request['fhirAuthorization'].except('access_token')
 
-    invalid_hook_request = appointment_book_hook_request_hash
-    invalid_hook_request['fhirAuthorization'] = invalid_hook_request['fhirAuthorization'].except('access_token')
+      create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message(index: 1).message).to match(
+        /Request 1: `fhirAuthorization` did not contain required field: `access_token`/
+      )
+    end
 
-    result = run(test)
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to eq('`fhirAuthorization` did not contain required field: `access_token`')
-  end
+    it 'fails if hook request fhirAuthorization `token_type` is not `Bearer`' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'fails if hook request fhirAuthorization `token_type` is not `Bearer`' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      invalid_hook_request = appointment_book_hook_request_hash
+      invalid_hook_request['fhirAuthorization']['token_type'] = 'Token'
 
-    invalid_hook_request = appointment_book_hook_request_hash
-    invalid_hook_request['fhirAuthorization']['token_type'] = 'Token'
+      create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message(index: 1).message).to match(
+        /Request 1: `fhirAuthorization` `token_type` field is not set to 'Bearer'/
+      )
+    end
 
-    result = run(test)
-    expect(result.result).to eq('fail')
-    expect(result.result_message).to eq("`fhirAuthorization` `token_type` field is not set to 'Bearer'")
-  end
+    it 'passes if patient scope included but `patient` field is omitted' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
 
-  it 'passes if patient scope included but `patient` field is omitted' do
-    token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
+      patient_scope_hook_request = appointment_book_hook_request_hash
+      patient_scope_hook_request['fhirAuthorization']['scope'] += ' patient/Patient.read'
 
-    patient_scope_hook_request = appointment_book_hook_request_hash
-    patient_scope_hook_request['fhirAuthorization']['scope'] += ' patient/Patient.read'
+      create_appointment_hook_request(body: patient_scope_hook_request, auth_header: "Bearer #{token}")
 
-    create_appointment_hook_request(body: patient_scope_hook_request, auth_header: "Bearer #{token}")
-
-    result = run(test)
-    expect(result.result).to eq('pass')
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
   end
 end

--- a/spec/davinci_crd_test_kit/hook_request_required_fields_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_required_fields_test_spec.rb
@@ -4,8 +4,11 @@ require_relative '../../lib/davinci_crd_test_kit/jwt_helper'
 RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:runnable) { Inferno::Repositories::Tests.new.find('crd_hook_request_required_fields') }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
 
   let(:example_client_url) { 'https://cds.example.org' }
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
@@ -46,19 +49,27 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
       name: 'appointment_book',
       direction: 'incoming',
       url:,
+      result:,
       test_session_id: test_session.id,
       request_body: body.is_a?(Hash) ? body.to_json : body,
       status:,
-      headers:
+      headers:,
+      tags: ['appointment-book']
     )
+  end
+
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+      .first
   end
 
   describe 'Appointment Book Hook Request Required Fields' do
     let(:test) do
       Class.new(DaVinciCRDTestKit::HookRequestRequiredFieldsTest) do
         config(
-          options: { hook_path: '/cds-services/appointment-book-service', hook_name: 'appointment-book' },
-          requests: { hook_request: { name: :appointment_book } }
+          options: { hook_path: '/cds-services/appointment-book-service', hook_name: 'appointment-book' }
         )
       end
     end
@@ -74,9 +85,44 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
       )
 
       create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
-
       result = run(test)
       expect(result.result).to eq('pass')
+    end
+
+    it 'passes if multiple valid hook request with all required fields included in request' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if one of multiple hook requests are invalid' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      invalid_hook_request = appointment_book_hook_request_hash.except('context')
+      create_appointment_hook_request(body: invalid_hook_request, auth_header: "Bearer #{token}")
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(
+        /Request 2: Hook request did not contain required field: `context`/
+      )
     end
 
     it 'skips if no appointment-book request can be found' do
@@ -84,7 +130,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
 
       result = run(test)
       expect(result.result).to eq('skip')
-      expect(result.result_message).to eq('Request `appointment_book` was not made in a previous test as expected.')
+      expect(result.result_message).to eq('No appointment-book requests were made in a previous test as expected.')
     end
 
     it 'fails if hook request body is not a valid json' do
@@ -101,7 +147,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
 
       result = run(test)
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Invalid JSON. ')
+      expect(entity_result_message.message).to match(/Request 1: Invalid JSON./)
     end
 
     it 'fails if hook request is missing a required field' do
@@ -120,7 +166,9 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
 
       result = run(test)
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Hook request did not contain required field: `context`')
+      expect(entity_result_message.message).to match(
+        /Request 1: Hook request did not contain required field: `context`/
+      )
     end
 
     it 'fails if hook request contains fhirAuthorization field but not fhirServer field' do
@@ -139,8 +187,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
 
       result = run(test)
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq(
-        'Missing `fhirServer` field: If `fhirAuthorization` is provided, this field is REQUIRED.'
+      expect(entity_result_message.message).to match(
+        /Missing `fhirServer` field: If `fhirAuthorization` is provided, this field is REQUIRED./
       )
     end
   end

--- a/spec/davinci_crd_test_kit/hook_request_required_fields_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_required_fields_test_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestRequiredFieldsTest do
       result = run(test)
       expect(result.result).to eq('fail')
       expect(entity_result_message.message).to match(
-        /Missing `fhirServer` field: If `fhirAuthorization` is provided, this field is REQUIRED./
+        /Missing `fhirServer` field: If `fhirAuthorization` is provided, this field is/
       )
     end
   end

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_appointment_book_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_appointment_book_spec.rb
@@ -195,13 +195,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       expect(result.result_message).to match("Input 'client_fhir_server' is nil, skipping test.")
     end
 
-    it 'fails if context is not a valid json' do
-      result = run(test, client_fhir_server:, client_access_token:,
-                         contexts: ['[['].to_json)
-      expect(result.result).to eq('fail')
-      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
-    end
-
     it 'fails if no request contains the `context` field' do
       result = run(test, client_fhir_server:, client_access_token:, contexts: [nil].to_json)
 

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_encounter_hook_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_encounter_hook_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     )
   end
 
+  let(:encounter_start_context) do
+    encounter_start_hook_request['context']
+  end
+
   let(:crd_patient) do
     JSON.parse(
       File.read(File.join(
@@ -83,34 +87,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  def create_encounter_start_request(url: encounter_start_url, body: nil, status: 200)
-    auth_token = klass.build(
-      aud: encounter_start_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
-
-    headers = [
-      {
-        type: 'request',
-        name: 'Authorization',
-        value: "Bearer #{auth_token}"
-      }
-    ]
-
-    repo_create(
-      :request,
-      name: 'encounter_start',
-      direction: 'incoming',
-      url:,
-      test_session_id: test_session.id,
-      request_body: body.is_a?(Hash) ? body.to_json : body,
-      status:,
-      headers:
-    )
-  end
-
   def entity_result_message(runnable)
     results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
       .first
@@ -134,10 +110,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
         end
         config(
-          options: { hook_name: 'encounter-start' },
-          requests: {
-            hook_request: { name: :encounter_start }
-          }
+          options: { hook_name: 'encounter-start' }
         )
       end
     end
@@ -160,11 +133,11 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
         )
         .to_return(status: 200, body: crd_encounter.to_json)
-      create_encounter_start_request(body: encounter_start_hook_request)
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(3)
@@ -173,10 +146,71 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       expect(encounter_resource_request).to have_been_made
     end
 
-    it 'skips if no client fhir server url is found' do
-      create_encounter_start_request(body: encounter_start_hook_request)
+    it 'passes if multiple hook requests have `context` that contains all required fields and valid fhir resources' do
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome_success.to_json)
+      patient_resource_request = stub_request(:get, "#{client_fhir_server}/Patient/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_patient.to_json)
+      practitioner_resource_request = stub_request(:get, "#{client_fhir_server}/Practitioner/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_practitioner.to_json)
+      encounter_resource_request = stub_request(:get, "#{client_fhir_server}/Encounter/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_encounter.to_json)
 
-      result = run(test)
+      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
+                         contexts_prefetches:
+                         [{ context: encounter_start_context }, { context: encounter_start_context }].to_json)
+      expect(result.result).to eq('pass')
+      expect(validation_request).to have_been_made.times(6)
+      expect(patient_resource_request).to have_been_made.times(2)
+      expect(practitioner_resource_request).to have_been_made.times(2)
+      expect(encounter_resource_request).to have_been_made.times(2)
+    end
+
+    it 'fails if one of multiple hook requests are invalid' do
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome_success.to_json)
+      patient_resource_request = stub_request(:get, "#{client_fhir_server}/Patient/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_patient.to_json)
+      practitioner_resource_request = stub_request(:get, "#{client_fhir_server}/Practitioner/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_practitioner.to_json)
+      encounter_resource_request = stub_request(:get, "#{client_fhir_server}/Encounter/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_encounter.to_json)
+
+      invalid_hook_request = encounter_start_context.except('patientId')
+
+      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
+                         contexts_prefetches:
+                         [{ context: encounter_start_context }, { context: invalid_hook_request }].to_json)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message(test)).to match(
+        /Request 2: encounter-start request context does not contain required field `patientId`/
+      )
+      expect(validation_request).to have_been_made.times(5)
+      expect(patient_resource_request).to have_been_made
+      expect(practitioner_resource_request).to have_been_made.times(2)
+      expect(encounter_resource_request).to have_been_made.times(2)
+    end
+
+    it 'skips if no client fhir server url is found' do
+      result = run(test, contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to eq(
@@ -184,27 +218,20 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       )
     end
 
-    it 'fails if request body is not a valid json' do
-      create_encounter_start_request(body: 'invalid_request')
-
-      result = run(test,
-                   client_fhir_server:,
-                   client_access_token: client_bearer_token)
-
+    it 'fails if context is not a valid json' do
+      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
+                         contexts_prefetches: [{ context: '[[' }].to_json)
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Invalid JSON. ')
+      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
     end
 
     it 'fails if request body is does not contain the `context` field' do
-      invalid_hook_request = encounter_start_hook_request.except('context')
-      create_encounter_start_request(body: invalid_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token, contexts_prefetches: [{ context: nil }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Hook request does not contain required `context` field')
+      expect(result.result_message).to eq('No encounter-start requests contained the `context` field.')
     end
 
     it 'fails if context does not contain all required fields' do
@@ -219,12 +246,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
         )
         .to_return(status: 200, body: crd_practitioner.to_json)
-      encounter_start_hook_request['context'].delete('encounterId')
-      create_encounter_start_request(body: encounter_start_hook_request)
+      encounter_start_context.delete('encounterId')
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -245,12 +272,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_encounter.to_json)
 
-      encounter_start_hook_request['context']['userId'] = '/'
-      create_encounter_start_request(body: encounter_start_hook_request)
+      encounter_start_context['userId'] = '/'
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Invalid `userId` format./)
@@ -269,12 +296,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_encounter.to_json)
 
-      encounter_start_hook_request['context']['userId'] = 'Observation/example'
-      create_encounter_start_request(body: encounter_start_hook_request)
+      encounter_start_context['userId'] = 'Observation/example'
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unsupported resource type: `userId` type should be/)
@@ -298,11 +325,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_encounter.to_json)
 
-      create_encounter_start_request(body: encounter_start_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unexpected response status: expected 200, but received 404/)
@@ -330,11 +356,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_practitioner.to_json)
 
-      create_encounter_start_request(body: encounter_start_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to/)

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_encounter_hook_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_encounter_hook_spec.rb
@@ -218,13 +218,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       )
     end
 
-    it 'fails if context is not a valid json' do
-      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts: ['[['].to_json)
-      expect(result.result).to eq('fail')
-      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
-    end
-
     it 'fails if request body is does not contain the `context` field' do
       result = run(test,
                    client_fhir_server:,

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_encounter_hook_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_encounter_hook_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
+                   contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(3)
@@ -166,8 +166,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         .to_return(status: 200, body: crd_encounter.to_json)
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: encounter_start_context }, { context: encounter_start_context }].to_json)
+                         contexts:
+                         [encounter_start_context, encounter_start_context].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(6)
       expect(patient_resource_request).to have_been_made.times(2)
@@ -197,8 +197,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       invalid_hook_request = encounter_start_context.except('patientId')
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: encounter_start_context }, { context: invalid_hook_request }].to_json)
+                         contexts:
+                         [encounter_start_context, invalid_hook_request].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
         /Request 2: encounter-start request context does not contain required field `patientId`/
@@ -210,7 +210,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     end
 
     it 'skips if no client fhir server url is found' do
-      result = run(test, contexts_prefetches: [{ context: encounter_start_context }].to_json)
+      result = run(test, contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to eq(
@@ -220,7 +220,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
 
     it 'fails if context is not a valid json' do
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches: [{ context: '[[' }].to_json)
+                         contexts: ['[['].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
     end
@@ -228,9 +228,9 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     it 'fails if request body is does not contain the `context` field' do
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token, contexts_prefetches: [{ context: nil }].to_json)
+                   client_access_token: client_bearer_token, contexts: [nil].to_json)
 
-      expect(result.result).to eq('fail')
+      expect(result.result).to eq('skip')
       expect(result.result_message).to eq('No encounter-start requests contained the `context` field.')
     end
 
@@ -251,7 +251,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
+                   contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -277,7 +277,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
+                   contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Invalid `userId` format./)
@@ -301,7 +301,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
+                   contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unsupported resource type: `userId` type should be/)
@@ -328,7 +328,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
+                   contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unexpected response status: expected 200, but received 404/)
@@ -359,7 +359,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: encounter_start_context }].to_json)
+                   contexts: [encounter_start_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to/)

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_dispatch_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_dispatch_spec.rb
@@ -219,13 +219,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       )
     end
 
-    it 'fails if context is not a valid json' do
-      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts: ['[['].to_json)
-      expect(result.result).to eq('fail')
-      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
-    end
-
     it 'fails if request body is does not contain the `context` field' do
       result = run(test,
                    client_fhir_server:,

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_dispatch_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_dispatch_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -167,8 +167,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         .to_return(status: 200, body: crd_service_request.to_json)
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: order_dispatch_context }, { context: order_dispatch_context }].to_json)
+                         contexts:
+                         [order_dispatch_context, order_dispatch_context].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(8)
       expect(patient_resource_request).to have_been_made.times(2)
@@ -198,8 +198,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       invalid_hook_request = order_dispatch_context.except('patientId')
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: order_dispatch_context }, { context: invalid_hook_request }].to_json)
+                         contexts:
+                         [order_dispatch_context, invalid_hook_request].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
         /Request 2: order-dispatch request context does not contain required field `patientId`/
@@ -211,7 +211,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     end
 
     it 'skips if no client fhir server url is found' do
-      result = run(test, contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+      result = run(test, contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to eq(
@@ -221,7 +221,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
 
     it 'fails if context is not a valid json' do
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches: [{ context: '[[' }].to_json)
+                         contexts: ['[['].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
     end
@@ -230,9 +230,9 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: nil }].to_json)
+                   contexts: [nil].to_json)
 
-      expect(result.result).to eq('fail')
+      expect(result.result).to eq('skip')
       expect(result.result_message).to eq('No order-dispatch requests contained the `context` field.')
     end
 
@@ -254,7 +254,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -280,7 +280,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Invalid `performer` format./)
@@ -307,7 +307,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unexpected response status: expected 200, but received 404/)
@@ -338,7 +338,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to/)
@@ -371,7 +371,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Field `task` must be a `Task`/)
@@ -406,7 +406,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_dispatch_context }].to_json)
+                   contexts: [order_dispatch_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to/)

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_select_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_select_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -160,8 +160,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         .to_return(status: 200, body: crd_practitioner.to_json)
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: order_select_context }, { context: order_select_context }].to_json)
+                         contexts:
+                         [order_select_context, order_select_context].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(8)
       expect(patient_resource_request).to have_been_made.times(2)
@@ -185,8 +185,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       invalid_hook_request = order_select_context.except('patientId')
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: order_select_context }, { context: invalid_hook_request }].to_json)
+                         contexts:
+                         [order_select_context, invalid_hook_request].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
         /Request 2: order-select request context does not contain required field `patientId`/
@@ -197,7 +197,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     end
 
     it 'skips if no client fhir server url is found' do
-      result = run(test, contexts_prefetches: [{ context: order_select_context }].to_json)
+      result = run(test, contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to eq(
@@ -207,7 +207,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
 
     it 'fails if context is not a valid json' do
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches: [{ context: '[[' }].to_json)
+                         contexts: ['[['].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
     end
@@ -216,9 +216,9 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: nil }].to_json)
+                   contexts: [nil].to_json)
 
-      expect(result.result).to eq('fail')
+      expect(result.result).to eq('skip')
       expect(result.result_message).to eq('No order-select requests contained the `context` field.')
     end
 
@@ -234,7 +234,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -254,7 +254,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Invalid `userId` format./)
@@ -272,7 +272,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unsupported resource type/)
@@ -294,7 +294,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unexpected response status: expected 200, but received 404/)
@@ -319,7 +319,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to/)
@@ -352,7 +352,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(5)
@@ -379,7 +379,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Wrong context resource type: Expected `Bundle`/)
@@ -405,7 +405,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -448,7 +448,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/NutritionOrder#pureeddiet-simple is invalid/)
@@ -476,7 +476,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_select_context }].to_json)
+                   contexts: [order_select_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_select_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_select_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     )
   end
 
+  let(:order_select_context) do
+    order_select_hook_request['context']
+  end
+
   let(:crd_patient) do
     JSON.parse(
       File.read(File.join(
@@ -88,34 +92,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  def create_order_select_hook_request(url: order_select_url, body: nil, status: 200)
-    auth_token = klass.build(
-      aud: order_select_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
-
-    headers = [
-      {
-        type: 'request',
-        name: 'Authorization',
-        value: "Bearer #{auth_token}"
-      }
-    ]
-
-    repo_create(
-      :request,
-      name: 'order_select',
-      direction: 'incoming',
-      url:,
-      test_session_id: test_session.id,
-      request_body: body.is_a?(Hash) ? body.to_json : body,
-      status:,
-      headers:
-    )
-  end
-
   def entity_result_message(runnable)
     results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
       .first
@@ -139,10 +115,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
         end
         config(
-          options: { hook_name: 'order-select' },
-          requests: {
-            hook_request: { name: :order_select }
-          }
+          options: { hook_name: 'order-select' }
         )
       end
     end
@@ -161,11 +134,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_practitioner.to_json)
 
-      create_order_select_hook_request(body: order_select_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -173,10 +145,59 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       expect(practitioner_resource_request).to have_been_made
     end
 
-    it 'skips if no client fhir server url is found' do
-      create_order_select_hook_request(body: order_select_hook_request)
+    it 'passes if multiple hook requests have `context` that contains all required fields and valid fhir resources' do
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome_success.to_json)
+      patient_resource_request = stub_request(:get, "#{client_fhir_server}/Patient/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_patient.to_json)
+      practitioner_resource_request = stub_request(:get, "#{client_fhir_server}/Practitioner/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_practitioner.to_json)
 
-      result = run(test)
+      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
+                         contexts_prefetches:
+                         [{ context: order_select_context }, { context: order_select_context }].to_json)
+      expect(result.result).to eq('pass')
+      expect(validation_request).to have_been_made.times(8)
+      expect(patient_resource_request).to have_been_made.times(2)
+      expect(practitioner_resource_request).to have_been_made.times(2)
+    end
+
+    it 'fails if one of multiple hook requests are invalid' do
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome_success.to_json)
+      patient_resource_request = stub_request(:get, "#{client_fhir_server}/Patient/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_patient.to_json)
+      practitioner_resource_request = stub_request(:get, "#{client_fhir_server}/Practitioner/example")
+        .with(
+          headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
+        )
+        .to_return(status: 200, body: crd_practitioner.to_json)
+
+      invalid_hook_request = order_select_context.except('patientId')
+
+      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
+                         contexts_prefetches:
+                         [{ context: order_select_context }, { context: invalid_hook_request }].to_json)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message(test)).to match(
+        /Request 2: order-select request context does not contain required field `patientId`/
+      )
+      expect(validation_request).to have_been_made.times(7)
+      expect(patient_resource_request).to have_been_made
+      expect(practitioner_resource_request).to have_been_made.times(2)
+    end
+
+    it 'skips if no client fhir server url is found' do
+      result = run(test, contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to eq(
@@ -184,27 +205,21 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       )
     end
 
-    it 'fails if request body is not a valid json' do
-      create_order_select_hook_request(body: 'invalid_request')
-
-      result = run(test,
-                   client_fhir_server:,
-                   client_access_token: client_bearer_token)
-
+    it 'fails if context is not a valid json' do
+      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
+                         contexts_prefetches: [{ context: '[[' }].to_json)
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Invalid JSON. ')
+      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
     end
 
     it 'fails if request body is does not contain the `context` field' do
-      invalid_hook_request = order_select_hook_request.except('context')
-      create_order_select_hook_request(body: invalid_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: nil }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to eq('Hook request does not contain required `context` field')
+      expect(result.result_message).to eq('No order-select requests contained the `context` field.')
     end
 
     it 'fails if context does not contain all required fields' do
@@ -214,12 +229,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
         )
         .to_return(status: 200, body: crd_practitioner.to_json)
-      order_select_hook_request['context'].delete('patientId')
-      create_order_select_hook_request(body: order_select_hook_request)
+      order_select_context.delete('patientId')
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -234,12 +249,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
         )
         .to_return(status: 200, body: crd_patient.to_json)
-      order_select_hook_request['context']['userId'] = '/'
-      create_order_select_hook_request(body: order_select_hook_request)
+      order_select_context['userId'] = '/'
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Invalid `userId` format./)
@@ -252,12 +267,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
           headers: { Authorization: 'Bearer SAMPLE_TOKEN' }
         )
         .to_return(status: 200, body: crd_patient.to_json)
-      order_select_hook_request['context']['userId'] = 'Observation/example'
-      create_order_select_hook_request(body: order_select_hook_request)
+      order_select_context['userId'] = 'Observation/example'
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unsupported resource type/)
@@ -276,11 +291,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_patient.to_json)
 
-      create_order_select_hook_request(body: order_select_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unexpected response status: expected 200, but received 404/)
@@ -302,11 +316,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_patient.to_json)
 
-      create_order_select_hook_request(body: order_select_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to/)
@@ -336,11 +349,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
 
       order_select_hook_request['context']['encounterId'] = 'example'
 
-      create_order_select_hook_request(body: order_select_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(5)
@@ -362,13 +374,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_patient.to_json)
 
-      order_select_hook_request['context']['draftOrders'] = crd_patient
-
-      create_order_select_hook_request(body: order_select_hook_request)
+      order_select_context['draftOrders'] = crd_patient
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Wrong context resource type: Expected `Bundle`/)
@@ -391,11 +402,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         entry['resource'] = crd_patient
       end
 
-      create_order_select_hook_request(body: order_select_hook_request)
-
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -433,13 +443,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_practitioner.to_json)
 
-      order_select_hook_request['context']['draftOrders']['entry'][0]['resource']['status'] = 'active'
-
-      create_order_select_hook_request(body: order_select_hook_request)
+      order_select_context['draftOrders']['entry'][0]['resource']['status'] = 'active'
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/NutritionOrder#pureeddiet-simple is invalid/)
@@ -462,13 +471,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         )
         .to_return(status: 200, body: crd_patient.to_json)
 
-      order_select_hook_request['context']['draftOrders']['entry'][0]['resource']['id'] = 'new_id'
-
-      create_order_select_hook_request(body: order_select_hook_request)
+      order_select_context['draftOrders']['entry'][0]['resource']['id'] = 'new_id'
 
       result = run(test,
                    client_fhir_server:,
-                   client_access_token: client_bearer_token)
+                   client_access_token: client_bearer_token,
+                   contexts_prefetches: [{ context: order_select_context }].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_select_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_select_spec.rb
@@ -205,13 +205,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       )
     end
 
-    it 'fails if context is not a valid json' do
-      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts: ['[['].to_json)
-      expect(result.result).to eq('fail')
-      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
-    end
-
     it 'fails if request body is does not contain the `context` field' do
       result = run(test,
                    client_fhir_server:,

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_sign_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_sign_spec.rb
@@ -201,13 +201,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       )
     end
 
-    it 'fails if context is not a valid json' do
-      result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts: ['[['].to_json)
-      expect(result.result).to eq('fail')
-      expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
-    end
-
     it 'fails if request body is does not contain the `context` field' do
       result = run(test,
                    client_fhir_server:,

--- a/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_sign_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_context_test_order_sign_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -156,8 +156,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
         .to_return(status: 200, body: crd_practitioner.to_json)
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: order_sign_context }, { context: order_sign_context }].to_json)
+                         contexts:
+                         [order_sign_context, order_sign_context].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(8)
       expect(patient_resource_request).to have_been_made.times(2)
@@ -181,8 +181,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       invalid_hook_request = order_sign_context.except('patientId')
 
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches:
-                         [{ context: order_sign_context }, { context: invalid_hook_request }].to_json)
+                         contexts:
+                         [order_sign_context, invalid_hook_request].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
         /Request 2: order-sign request context does not contain required field `patientId`/
@@ -193,7 +193,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
     end
 
     it 'skips if no client fhir server url is found' do
-      result = run(test, contexts_prefetches: [{ context: order_sign_context }].to_json)
+      result = run(test, contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to eq(
@@ -203,7 +203,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
 
     it 'fails if context is not a valid json' do
       result = run(test, client_fhir_server:, client_access_token: client_bearer_token,
-                         contexts_prefetches: [{ context: '[[' }].to_json)
+                         contexts: ['[['].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Context is in an incorrect format./)
     end
@@ -212,9 +212,9 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: nil }].to_json)
+                   contexts: [nil].to_json)
 
-      expect(result.result).to eq('fail')
+      expect(result.result).to eq('skip')
       expect(result.result_message).to eq('No order-sign requests contained the `context` field.')
     end
 
@@ -230,7 +230,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -251,7 +251,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Invalid `userId` format./)
@@ -270,7 +270,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unsupported resource type: `userId` type should be/)
@@ -293,7 +293,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Unexpected response status: expected 200, but received 404/)
@@ -319,7 +319,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match('Resource does not conform to profile')
@@ -351,7 +351,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(5)
@@ -378,7 +378,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Wrong context resource type: Expected `Bundle`, got `Patient`/)
@@ -404,7 +404,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -446,7 +446,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidContextTest do
       result = run(test,
                    client_fhir_server:,
                    client_access_token: client_bearer_token,
-                   contexts_prefetches: [{ context: order_sign_context }].to_json)
+                   contexts: [order_sign_context].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/NutritionOrder#pureeddiet-simple is invalid/)

--- a/spec/davinci_crd_test_kit/hook_request_valid_prefetch_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_prefetch_test_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
       result = run(test,
-                   contexts_prefetches: [{ context: appointment_book_context,
-                                           prefetch: appointment_book_prefetch }].to_json)
+                   contexts: [appointment_book_context].to_json,
+                   prefetches: [appointment_book_prefetch].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(3)
     end
@@ -201,10 +201,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
       result = run(test,
-                   contexts_prefetches: [{ context: appointment_book_context,
-                                           prefetch: appointment_book_prefetch },
-                                         { context: appointment_book_context,
-                                           prefetch: appointment_book_prefetch }].to_json)
+                   contexts: [appointment_book_context, appointment_book_context].to_json,
+                   prefetches: [appointment_book_prefetch, appointment_book_prefetch].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(6)
     end
@@ -216,10 +214,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       invalid_prefetch = { user: crd_practitioner, patient: crd_practitioner, coverage: crd_coverage_bundle }
 
       result = run(test,
-                   contexts_prefetches: [{ context: appointment_book_context,
-                                           prefetch: appointment_book_prefetch },
-                                         { context: appointment_book_context,
-                                           prefetch: invalid_prefetch }].to_json)
+                   contexts: [appointment_book_context, appointment_book_context].to_json,
+                   prefetches: [appointment_book_prefetch, invalid_prefetch].to_json)
       expect(result.result).to eq('fail')
       expect(validation_request).to have_been_made.times(4)
       expect(entity_result_message(test)).to match(
@@ -228,8 +224,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
     end
 
     it 'skips if hook request does not contain the `prefetch` field' do
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: nil }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [nil].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to match(
@@ -238,8 +233,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
     end
 
     it 'skips if hook request does not contain the `context` field' do
-      result = run(test, contexts_prefetches: [{ context: nil,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [nil].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('skip')
       expect(result.result_message).to match(
@@ -252,8 +246,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       appointment_book_prefetch[:user]['resourceType'] = 'Observation'
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -268,8 +261,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       appointment_book_prefetch.delete(:patient)
       appointment_book_prefetch.delete(:coverage)
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to profile/)
@@ -281,8 +273,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       appointment_book_prefetch[:user]['id'] = 'incorrect_id'
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Expected `user` field's FHIR resource to have an `id` of 'example'/)
@@ -293,8 +284,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       appointment_book_prefetch[:patient]['resourceType'] = 'Practitioner'
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -309,8 +299,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       appointment_book_prefetch.delete(:user)
       appointment_book_prefetch.delete(:coverage)
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to profile/)
@@ -322,8 +311,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       appointment_book_prefetch[:patient]['id'] = 'incorrect_id'
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -337,8 +325,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       appointment_book_prefetch[:coverage].entry.first.resource =
         FHIR.from_contents(crd_practitioner.to_json)
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -353,8 +340,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       appointment_book_prefetch.delete(:user)
       appointment_book_prefetch.delete(:patient)
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Resource does not conform to profile/)
@@ -367,8 +353,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       appointment_book_prefetch[:coverage].entry.first.resource.beneficiary.reference =
         'Patient/incorrect_id'
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
@@ -381,8 +366,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       appointment_book_prefetch[:coverage].entry.first.resource.status =
         'draft'
 
-      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
-                                                 prefetch: appointment_book_prefetch }].to_json)
+      result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(/Expected `coverage` field's Coverage resource to have a `status`/)
     end
@@ -412,8 +396,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      result = run(test, contexts_prefetches: [{ context: encounter_start_context,
-                                                 prefetch: encounter_start_hook_prefetch }].to_json)
+      result = run(test, contexts: [encounter_start_context].to_json,
+                         prefetches: [encounter_start_hook_prefetch].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -444,8 +428,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      result = run(test, contexts_prefetches: [{ context: order_dispatch_context,
-                                                 prefetch: order_dispatch_hook_prefetch }].to_json)
+      result = run(test, contexts: [order_dispatch_context].to_json, prefetches: [order_dispatch_hook_prefetch].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -476,8 +459,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      result = run(test, contexts_prefetches: [{ context: order_select_context,
-                                                 prefetch: order_select_hook_prefetch }].to_json)
+      result = run(test, contexts: [order_select_context].to_json, prefetches: [order_select_hook_prefetch].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(3)

--- a/spec/davinci_crd_test_kit/hook_request_valid_prefetch_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_prefetch_test_spec.rb
@@ -3,7 +3,9 @@ require_relative '../../lib/davinci_crd_test_kit/jwt_helper'
 
 RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
+  let(:runnable) { Inferno::Repositories::Tests.new.find('crd_hook_request_valid_prefetch') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
 
@@ -91,27 +93,31 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
     )
   end
 
-  let(:appointment_book_hook_request_with_prefetch) do
-    request = appointment_book_hook_request
-    request['prefetch'] = { user: crd_practitioner, patient: crd_patient, coverage: crd_coverage_bundle }
-    request
+  let(:appointment_book_prefetch) do
+    { user: crd_practitioner, patient: crd_patient, coverage: crd_coverage_bundle }
   end
-  let(:encounter_start_hook_request_with_prefetch) do
-    request = encounter_start_hook_request
-    request['prefetch'] = { user: crd_practitioner, patient: crd_patient, encounter: crd_encounter,
-                            coverage: crd_coverage_bundle }
-    request
+  let(:appointment_book_context) do
+    appointment_book_hook_request['context']
   end
-  let(:order_dispatch_hook_request_with_prefetch) do
-    request = order_dispatch_hook_request
-    request['prefetch'] = { performer: crd_practitioner, patient: crd_patient, order: crd_service_request,
-                            coverage: crd_coverage_bundle }
-    request
+  let(:encounter_start_hook_prefetch) do
+    { user: crd_practitioner, patient: crd_patient, encounter: crd_encounter,
+      coverage: crd_coverage_bundle }
   end
-  let(:order_select_hook_request_with_prefetch) do
-    request = order_select_hook_request
-    request['prefetch'] = { user: crd_practitioner, patient: crd_patient, coverage: crd_coverage_bundle }
-    request
+  let(:encounter_start_context) do
+    encounter_start_hook_request['context']
+  end
+  let(:order_dispatch_hook_prefetch) do
+    { performer: crd_practitioner, patient: crd_patient, order: crd_service_request,
+      coverage: crd_coverage_bundle }
+  end
+  let(:order_dispatch_context) do
+    order_dispatch_hook_request['context']
+  end
+  let(:order_select_hook_prefetch) do
+    { user: crd_practitioner, patient: crd_patient, coverage: crd_coverage_bundle }
+  end
+  let(:order_select_context) do
+    order_select_hook_request['context']
   end
 
   let(:operation_outcome_success) do
@@ -151,32 +157,12 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
 
-  def create_hook_request(url: appointment_book_url, body: nil, status: 200, hook_name: 'appointment_book')
-    auth_token = jwt_helper.build(
-      aud: appointment_book_url,
-      iss: example_client_url,
-      jku: "#{example_client_url}/jwks.json",
-      encryption_method: 'RS384'
-    )
-
-    headers = [
-      {
-        type: 'request',
-        name: 'Authorization',
-        value: "Bearer #{auth_token}"
-      }
-    ]
-
-    repo_create(
-      :request,
-      name: hook_name,
-      direction: 'incoming',
-      url:,
-      test_session_id: test_session.id,
-      request_body: body.is_a?(Hash) ? body.to_json : body,
-      status:,
-      headers:
-    )
+  def entity_result_message(runnable)
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+      .map(&:message)
+      .join(' ')
   end
 
   describe 'Appointment Book Hook Valid Prefetch' do
@@ -194,8 +180,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
           igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
         end
         config(
-          options: { hook_name: 'appointment-book' },
-          requests: { hook_request: { name: :appointment_book } }
+          options: { hook_name: 'appointment-book' }
         )
       end
     end
@@ -204,44 +189,75 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test,
+                   contexts_prefetches: [{ context: appointment_book_context,
+                                           prefetch: appointment_book_prefetch }].to_json)
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(3)
     end
 
-    it 'skips if hook request does not contain the `prefetch` field' do
-      create_hook_request(body: appointment_book_hook_request)
+    it 'passes if multiple requests have prefetch with valid resources for `user`, `patient`, and `coverage` fields' do
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      result = run(test)
+      result = run(test,
+                   contexts_prefetches: [{ context: appointment_book_context,
+                                           prefetch: appointment_book_prefetch },
+                                         { context: appointment_book_context,
+                                           prefetch: appointment_book_prefetch }].to_json)
+      expect(result.result).to eq('pass')
+      expect(validation_request).to have_been_made.times(6)
+    end
+
+    it 'fails if one request of many has an invalid prefetch field' do
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .to_return(status: 200, body: operation_outcome_success.to_json)
+
+      invalid_prefetch = { user: crd_practitioner, patient: crd_practitioner, coverage: crd_coverage_bundle }
+
+      result = run(test,
+                   contexts_prefetches: [{ context: appointment_book_context,
+                                           prefetch: appointment_book_prefetch },
+                                         { context: appointment_book_context,
+                                           prefetch: invalid_prefetch }].to_json)
+      expect(result.result).to eq('fail')
+      expect(validation_request).to have_been_made.times(4)
+      expect(entity_result_message(test)).to match(
+        /Request 2: Unexpected resource type: expected Patient, but received Practitioner/
+      )
+    end
+
+    it 'skips if hook request does not contain the `prefetch` field' do
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: nil }].to_json)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to eq('Received hook request does not contain the `prefetch` field.')
+      expect(result.result_message).to match(
+        'No appointment-book requests contained both the `context` and `prefetch` field'
+      )
     end
 
     it 'skips if hook request does not contain the `context` field' do
-      appointment_book_hook_no_context = appointment_book_hook_request_with_prefetch.except('context')
-      create_hook_request(body: appointment_book_hook_no_context)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: nil,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('skip')
-      expect(result.result_message).to match('Received hook request does not contain the `context` field')
+      expect(result.result_message).to match(
+        'No appointment-book requests contained both the `context` and `prefetch` field'
+      )
     end
 
     it 'fails if prefetch `user` is not a valid resource type' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
 
-      appointment_book_hook_request_with_prefetch['prefetch'][:user]['resourceType'] = 'Observation'
+      appointment_book_prefetch[:user]['resourceType'] = 'Observation'
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match(
-        'Unexpected resource type: expected Practitioner, but received Observation'
+      expect(entity_result_message(test)).to match(
+        /Unexpected resource type: expected Practitioner, but received Observation/
       )
     end
 
@@ -249,128 +265,126 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       practitioner_validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_failure.to_json)
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
+      appointment_book_prefetch.delete(:patient)
+      appointment_book_prefetch.delete(:coverage)
 
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match('Resource does not conform to the profile: http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-practitioner')
+      expect(entity_result_message(test)).to match(/Resource does not conform to profile/)
       expect(practitioner_validation_request).to have_been_made
     end
 
     it 'fails if prefetch `user` has wrong id' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
 
-      appointment_book_hook_request_with_prefetch['prefetch'][:user]['id'] = 'incorrect_id'
+      appointment_book_prefetch[:user]['id'] = 'incorrect_id'
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match("Expected `user` field's FHIR resource to have an `id` of 'example'")
+      expect(entity_result_message(test)).to match(/Expected `user` field's FHIR resource to have an `id` of 'example'/)
     end
 
     it 'fails if prefetch `patient` is not a Patient resource' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
 
-      appointment_book_hook_request_with_prefetch['prefetch'][:patient]['resourceType'] = 'Practitioner'
+      appointment_book_prefetch[:patient]['resourceType'] = 'Practitioner'
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match('Unexpected resource type: expected Patient, but received Practitioner')
+      expect(entity_result_message(test)).to match(
+        /Unexpected resource type: expected Patient, but received Practitioner/
+      )
     end
 
     it 'fails if prefetch `patient` fails validation' do
       patient_validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_failure.to_json)
 
-      appointment_book_hook_request_with_prefetch['prefetch'].delete(:user)
-      appointment_book_hook_request_with_prefetch['prefetch'].delete(:coverage)
+      appointment_book_prefetch.delete(:user)
+      appointment_book_prefetch.delete(:coverage)
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match('Resource does not conform to the profile: http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-patient')
+      expect(entity_result_message(test)).to match(/Resource does not conform to profile/)
       expect(patient_validation_request).to have_been_made
     end
 
     it 'fails if prefetch `patient` has wrong id' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
 
-      appointment_book_hook_request_with_prefetch['prefetch'][:patient]['id'] = 'incorrect_id'
+      appointment_book_prefetch[:patient]['id'] = 'incorrect_id'
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match("Expected `patient` field's FHIR resource to have an `id` of 'example'")
+      expect(entity_result_message(test)).to match(
+        /Expected `patient` field's FHIR resource to have an `id` of 'example'/
+      )
     end
 
     it 'fails if prefetch `coverage` is not a Coverage resource' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
 
-      appointment_book_hook_request_with_prefetch['prefetch'][:coverage].entry.first.resource =
+      appointment_book_prefetch[:coverage].entry.first.resource =
         FHIR.from_contents(crd_practitioner.to_json)
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match('Unexpected resource type: expected Coverage, but received Practitioner')
+      expect(entity_result_message(test)).to match(
+        /Unexpected resource type: expected Coverage, but received Practitioner/
+      )
     end
 
     it 'fails if prefetch `coverage` fails validation' do
       coverage_validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_failure.to_json)
 
-      appointment_book_hook_request_with_prefetch['prefetch'].delete(:user)
-      appointment_book_hook_request_with_prefetch['prefetch'].delete(:patient)
+      appointment_book_prefetch.delete(:user)
+      appointment_book_prefetch.delete(:patient)
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match('Resource does not conform to the profile: http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-coverage')
+      expect(entity_result_message(test)).to match(/Resource does not conform to profile/)
       expect(coverage_validation_request).to have_been_made
     end
 
     it 'fails if prefetch `coverage` has wrong beneficiary id' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
 
-      appointment_book_hook_request_with_prefetch['prefetch'][:coverage].entry.first.resource.beneficiary.reference =
+      appointment_book_prefetch[:coverage].entry.first.resource.beneficiary.reference =
         'Patient/incorrect_id'
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
 
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match(
-        "Expected `coverage` field's Coverage resource to have a `beneficiary` reference id of"
+      expect(entity_result_message(test)).to match(
+        /Expected `coverage` field's Coverage resource to have a `beneficiary` reference id of/
       )
     end
 
     it 'fails if prefetch `coverage` has wrong status' do
       allow_any_instance_of(test).to receive(:resource_is_valid?).and_return(true)
-      appointment_book_hook_request_with_prefetch['prefetch'][:coverage].entry.first.resource.status =
+      appointment_book_prefetch[:coverage].entry.first.resource.status =
         'draft'
 
-      create_hook_request(body: appointment_book_hook_request_with_prefetch)
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: appointment_book_context,
+                                                 prefetch: appointment_book_prefetch }].to_json)
       expect(result.result).to eq('fail')
-      expect(result.result_message).to match(
-        "Expected `coverage` field's Coverage resource to have a `status`"
-      )
+      expect(entity_result_message(test)).to match(/Expected `coverage` field's Coverage resource to have a `status`/)
     end
   end
 
@@ -389,8 +403,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
           igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
         end
         config(
-          options: { hook_name: 'encounter-start' },
-          requests: { hook_request: { name: :encounter_start } }
+          options: { hook_name: 'encounter-start' }
         )
       end
     end
@@ -399,9 +412,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      create_hook_request(body: encounter_start_hook_request_with_prefetch, hook_name: 'encounter_start')
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: encounter_start_context,
+                                                 prefetch: encounter_start_hook_prefetch }].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -423,8 +435,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
           igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
         end
         config(
-          options: { hook_name: 'order-dispatch' },
-          requests: { hook_request: { name: :order_dispatch } }
+          options: { hook_name: 'order-dispatch' }
         )
       end
     end
@@ -433,9 +444,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      create_hook_request(body: order_dispatch_hook_request_with_prefetch, hook_name: 'order_dispatch')
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: order_dispatch_context,
+                                                 prefetch: order_dispatch_hook_prefetch }].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(4)
@@ -457,8 +467,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
           igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
         end
         config(
-          options: { hook_name: 'order-select' },
-          requests: { hook_request: { name: :order_select } }
+          options: { hook_name: 'order-select' }
         )
       end
     end
@@ -467,9 +476,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .to_return(status: 200, body: operation_outcome_success.to_json)
 
-      create_hook_request(body: order_select_hook_request_with_prefetch, hook_name: 'order_select')
-
-      result = run(test)
+      result = run(test, contexts_prefetches: [{ context: order_select_context,
+                                                 prefetch: order_select_hook_prefetch }].to_json)
 
       expect(result.result).to eq('pass')
       expect(validation_request).to have_been_made.times(3)

--- a/spec/davinci_crd_test_kit/hook_request_valid_prefetch_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_valid_prefetch_test_spec.rb
@@ -217,9 +217,9 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
                    contexts: [appointment_book_context, appointment_book_context].to_json,
                    prefetches: [appointment_book_prefetch, invalid_prefetch].to_json)
       expect(result.result).to eq('fail')
-      expect(validation_request).to have_been_made.times(4)
+      expect(validation_request).to have_been_made.times(5)
       expect(entity_result_message(test)).to match(
-        /Request 2: Unexpected resource type: expected Patient, but received Practitioner/
+        /Request 2: Unexpected resource type: Expected `Patient`. Got/
       )
     end
 
@@ -250,7 +250,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
-        /Unexpected resource type: expected Practitioner, but received Observation/
+        /Unexpected resource type: Expected `Practitioner`. Got/
       )
     end
 
@@ -276,7 +276,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
       result = run(test, contexts: [appointment_book_context].to_json, prefetches: [appointment_book_prefetch].to_json)
 
       expect(result.result).to eq('fail')
-      expect(entity_result_message(test)).to match(/Expected `user` field's FHIR resource to have an `id` of 'example'/)
+      expect(entity_result_message(test)).to match(/Expected `user` field's FHIR resource to have an `id` of/)
     end
 
     it 'fails if prefetch `patient` is not a Patient resource' do
@@ -288,7 +288,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
-        /Unexpected resource type: expected Patient, but received Practitioner/
+        /Unexpected resource type: Expected `Patient`. Got/
       )
     end
 
@@ -315,7 +315,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
-        /Expected `patient` field's FHIR resource to have an `id` of 'example'/
+        /Expected `patient` field's FHIR resource to have an `id` of/
       )
     end
 
@@ -329,7 +329,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
-        /Unexpected resource type: expected Coverage, but received Practitioner/
+        /Unexpected resource type: Expected `Coverage`. Got/
       )
     end
 
@@ -357,7 +357,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestValidPrefetchTest do
 
       expect(result.result).to eq('fail')
       expect(entity_result_message(test)).to match(
-        /Expected `coverage` field's Coverage resource to have a `beneficiary` reference id of/
+        /Expected `coverage` field's Coverage resource to have a `beneficiary`/
       )
     end
 

--- a/spec/davinci_crd_test_kit/order_dispatch_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/order_dispatch_receive_request_test_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DaVinciCRDTestKit::OrderDispatchReceiveRequestTest do
 
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:test) { Inferno::Repositories::Tests.new.find('crd_order_dispatch_request') }
+  let(:test_group) { Inferno::Repositories::TestGroups.new.find('crd_client_hooks') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
@@ -63,7 +64,7 @@ RSpec.describe DaVinciCRDTestKit::OrderDispatchReceiveRequestTest do
   end
 
   it 'passes and responds 200 if request sent to the provided URL and jwt `iss` claim matches the given`iss`' do
-    allow(test).to receive(:suite).and_return(suite)
+    allow(test).to receive_messages(suite:, parent: test_group)
 
     token = jwt_helper.build(
       aud: order_dispatch_url,

--- a/spec/davinci_crd_test_kit/order_dispatch_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/order_dispatch_receive_request_test_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe DaVinciCRDTestKit::OrderDispatchReceiveRequestTest do
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
 
   let(:example_client_url) { 'https://cds.example.org' }
+  let(:resume_pass_url) do
+    "#{Inferno::Application['base_url']}/custom/crd_client/resume_pass?token=order-dispatch%20#{example_client_url}"
+  end
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
   let(:order_dispatch_url) { "#{base_url}/cds-services/order-dispatch-service" }
   let(:client_fhir_server) { 'https://example/r4' }
@@ -76,8 +79,9 @@ RSpec.describe DaVinciCRDTestKit::OrderDispatchReceiveRequestTest do
     body['prefetch'] = { 'coverage' => crd_coverage, 'order' => crd_order }
     header('Authorization', "Bearer #{token}")
     post_json(server_endpoint, body)
-
     expect(last_response).to be_ok
+    get(resume_pass_url)
+
     result = results_repo.find(result.id)
     expect(result.result).to eq('pass')
   end

--- a/spec/davinci_crd_test_kit/order_select_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/order_select_receive_request_test_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DaVinciCRDTestKit::OrderSelectReceiveRequestTest do
 
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:test) { Inferno::Repositories::Tests.new.find('crd_order_select_request') }
+  let(:test_group) { Inferno::Repositories::TestGroups.new.find('crd_client_hooks') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
@@ -58,7 +59,7 @@ RSpec.describe DaVinciCRDTestKit::OrderSelectReceiveRequestTest do
   end
 
   it 'passes and responds 200 if request sent to the provided URL and jwt `iss` claim matches the given`iss`' do
-    allow(test).to receive(:suite).and_return(suite)
+    allow(test).to receive_messages(suite:, parent: test_group)
 
     token = jwt_helper.build(
       aud: order_select_url,

--- a/spec/davinci_crd_test_kit/order_select_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/order_select_receive_request_test_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe DaVinciCRDTestKit::OrderSelectReceiveRequestTest do
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
 
   let(:example_client_url) { 'https://cds.example.org' }
+  let(:resume_pass_url) do
+    "#{Inferno::Application['base_url']}/custom/crd_client/resume_pass?token=order-select%20#{example_client_url}"
+  end
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
   let(:order_select_url) { "#{base_url}/cds-services/order-select-service" }
   let(:client_fhir_server) { 'https://example/r4' }
@@ -71,8 +74,9 @@ RSpec.describe DaVinciCRDTestKit::OrderSelectReceiveRequestTest do
     body['prefetch'] = { 'coverage' => crd_coverage }
     header('Authorization', "Bearer #{token}")
     post_json(server_endpoint, body)
-
     expect(last_response).to be_ok
+    get(resume_pass_url)
+
     result = results_repo.find(result.id)
     expect(result.result).to eq('pass')
   end

--- a/spec/davinci_crd_test_kit/order_sign_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/order_sign_receive_request_test_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe DaVinciCRDTestKit::OrderSignReceiveRequestTest do
   let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
 
   let(:example_client_url) { 'https://cds.example.org' }
+  let(:resume_pass_url) do
+    "#{Inferno::Application['base_url']}/custom/crd_client/resume_pass?token=order-sign%20#{example_client_url}"
+  end
   let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
   let(:order_sign_url) { "#{base_url}/cds-services/order-sign-service" }
   let(:client_fhir_server) { 'https://example/r4' }
@@ -71,8 +74,9 @@ RSpec.describe DaVinciCRDTestKit::OrderSignReceiveRequestTest do
     body['prefetch'] = { 'coverage' => crd_coverage }
     header('Authorization', "Bearer #{token}")
     post_json(server_endpoint, body)
-
     expect(last_response).to be_ok
+    get(resume_pass_url)
+
     result = results_repo.find(result.id)
     expect(result.result).to eq('pass')
   end

--- a/spec/davinci_crd_test_kit/order_sign_receive_request_test_spec.rb
+++ b/spec/davinci_crd_test_kit/order_sign_receive_request_test_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DaVinciCRDTestKit::OrderSignReceiveRequestTest do
 
   let(:suite) { Inferno::Repositories::TestSuites.new.find('crd_client') }
   let(:test) { Inferno::Repositories::Tests.new.find('crd_order_sign_request') }
+  let(:test_group) { Inferno::Repositories::TestGroups.new.find('crd_client_hooks') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'crd_client') }
@@ -58,7 +59,7 @@ RSpec.describe DaVinciCRDTestKit::OrderSignReceiveRequestTest do
   end
 
   it 'passes and responds 200 if request sent to the provided URL and jwt `iss` claim matches the given`iss`' do
-    allow(test).to receive(:suite).and_return(suite)
+    allow(test).to receive_messages(suite:, parent: test_group)
 
     token = jwt_helper.build(
       aud: order_sign_url,

--- a/spec/davinci_crd_test_kit/retrieve_jwks_test_spec.rb
+++ b/spec/davinci_crd_test_kit/retrieve_jwks_test_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     result = run(test, auth_tokens_header_json: [token_header.to_json, token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(
-      /Request 2: Unexpected response status: expected 200, but received 404/
+      /Request 2: Unexpected response status: expected 200, but received/
     )
     expect(jwks_request).to have_been_made.times(2)
   end
@@ -106,7 +106,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
 
     result = run(test, auth_tokens_header_json: [token_header.to_json])
     expect(result.result).to eq('fail')
-    expect(entity_result_message.message).to match(/Unexpected response status: expected 200, but received 404/)
+    expect(entity_result_message.message).to match(/Unexpected response status: expected 200, but received/)
     expect(jwks_request).to have_been_made
   end
 
@@ -157,7 +157,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
       .to_return(status: 200, body: jwks_hash_dup_kids.to_json)
     result = run(test, auth_tokens_header_json: [token_header.to_json])
     expect(result.result).to eq('fail')
-    expect(entity_result_message.message).to match(/`kid` must be unique within the client' JWK Set./)
+    expect(entity_result_message.message).to match(/`kid` must be unique within the client's JWK Set./)
     expect(jwks_request).to have_been_made
   end
 end

--- a/spec/davinci_crd_test_kit/retrieve_jwks_test_spec.rb
+++ b/spec/davinci_crd_test_kit/retrieve_jwks_test_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: jwks_hash.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('pass')
     expect(jwks_request).to have_been_made
   end
@@ -67,7 +67,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: jwks_hash.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json, token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json, token_header.to_json])
     expect(result.result).to eq('pass')
     expect(jwks_request).to have_been_made.times(2)
   end
@@ -77,7 +77,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
       .to_return(status: 200, body: jwks_hash.to_json).then
       .to_return(status: 404, body: jwks_hash.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json, token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json, token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(
       /Request 2: Unexpected response status: expected 200, but received/
@@ -88,14 +88,14 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
   it 'passes if it receives a valid jwk_set input' do
     token_header_no_jku = token_header.except(:jku)
 
-    result = run(test, auth_tokens_header_json: [token_header_no_jku.to_json], jwk_set: jwks_hash.to_json)
+    result = run(test, auth_token_headers_json: [token_header_no_jku.to_json], jwk_set: jwks_hash.to_json)
     expect(result.result).to eq('pass')
   end
 
   it 'skips if jku field is not set, and no jwk_set is provided' do
     token_header_no_jku = token_header.except(:jku)
 
-    result = run(test, auth_tokens_header_json: [token_header_no_jku.to_json])
+    result = run(test, auth_token_headers_json: [token_header_no_jku.to_json])
     expect(result.result).to eq('skip')
     expect(result.result_message).to match("JWK Set must be inputted if Client's JWK Set is not available")
   end
@@ -104,7 +104,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 404, body: jwks_hash.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Unexpected response status: expected 200, but received/)
     expect(jwks_request).to have_been_made
@@ -114,7 +114,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: nil)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Invalid JSON./)
     expect(jwks_request).to have_been_made
@@ -124,7 +124,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: jwk.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/JWKS `keys` field must be an array/)
     expect(jwks_request).to have_been_made
@@ -134,7 +134,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: jwks_hash_no_keys.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/The JWK set returned contains no public keys/)
     expect(jwks_request).to have_been_made
@@ -144,7 +144,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: jwks_hash_no_kids.to_json)
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(
       /`kid` field must be present in each key if JWKS contains multiple keys/
@@ -155,7 +155,7 @@ RSpec.describe DaVinciCRDTestKit::RetrieveJWKSTest do
   it 'fails if jwks returned contains duplicate kid fields' do
     jwks_request = stub_request(:get, "#{example_client_url}/jwks.json")
       .to_return(status: 200, body: jwks_hash_dup_kids.to_json)
-    result = run(test, auth_tokens_header_json: [token_header.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/`kid` must be unique within the client's JWK Set./)
     expect(jwks_request).to have_been_made

--- a/spec/davinci_crd_test_kit/service_request_context_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/service_request_context_validation_test_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe DaVinciCRDTestKit::ServiceRequestContextValidationTest do
       context_dup['task'] = { resourceType: 'Patient' }
       result = run(runnable, contexts: [context_dup].to_json)
       expect(result.result).to eq('fail')
-      expect(entity_result_message.message).to match(/Field `task` must be a `Task`. Got `Patient`/)
+      expect(entity_result_message.message).to match(/Field `task` must be a `Task`/)
     end
   end
 

--- a/spec/davinci_crd_test_kit/token_header_test_spec.rb
+++ b/spec/davinci_crd_test_kit/token_header_test_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
 
     result = run(test, auth_tokens_header_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
-    expect(entity_result_message.message).to match(/Token header `typ` field must be set to 'JWT', instead was Bearer/)
+    expect(entity_result_message.message).to match(/Token header `typ` field must be set to 'JWT', instead was/)
   end
 
   it 'fails if it receives a JWT header without the `kid` field' do

--- a/spec/davinci_crd_test_kit/token_header_test_spec.rb
+++ b/spec/davinci_crd_test_kit/token_header_test_spec.rb
@@ -43,19 +43,19 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
   end
 
   it 'passes if it receives a valid JWT Authorization header' do
-    result = run(test, auth_tokens_header_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('pass')
   end
 
   it 'passes if it receives multiple requests with valid JWT Authorization headers' do
-    result = run(test, auth_tokens_header_json: [token_header.to_json, token_header.to_json],
+    result = run(test, auth_token_headers_json: [token_header.to_json, token_header.to_json],
                        crd_jwks_keys_json: [jwks_hash_keys.to_json, jwks_hash_keys.to_json])
     expect(result.result).to eq('pass')
   end
 
   it 'fails if it receives at least 1 request with invalid JWT Authorization headers' do
     invalid_token_header = token_header.except(:alg)
-    result = run(test, auth_tokens_header_json: [token_header.to_json, invalid_token_header.to_json],
+    result = run(test, auth_token_headers_json: [token_header.to_json, invalid_token_header.to_json],
                        crd_jwks_keys_json: [jwks_hash_keys.to_json, jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Request 2: Token header must have the `alg` field/)
@@ -64,7 +64,7 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
   it 'fails if it receives a JWT header without the `alg` field' do
     invalid_token_header = token_header.except(:alg)
 
-    result = run(test, auth_tokens_header_json: [invalid_token_header.to_json],
+    result = run(test, auth_token_headers_json: [invalid_token_header.to_json],
                        crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Token header must have the `alg` field/)
@@ -73,7 +73,7 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
   it 'fails if it receives a JWT header without the `typ` field' do
     invalid_token_header = token_header.except(:typ)
 
-    result = run(test, auth_tokens_header_json: [invalid_token_header.to_json],
+    result = run(test, auth_token_headers_json: [invalid_token_header.to_json],
                        crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Token header must have the `typ` field/)
@@ -82,7 +82,7 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
   it 'fails if it receives a JWT header with the `typ` field not set to JWT' do
     token_header[:typ] = 'Bearer'
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Token header `typ` field must be set to 'JWT', instead was/)
   end
@@ -90,7 +90,7 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
   it 'fails if it receives a JWT header without the `kid` field' do
     invalid_token_header = token_header.except(:kid)
 
-    result = run(test, auth_tokens_header_json: [invalid_token_header.to_json],
+    result = run(test, auth_token_headers_json: [invalid_token_header.to_json],
                        crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/Token header must have the `kid` field/)
@@ -99,7 +99,7 @@ RSpec.describe DaVinciCRDTestKit::TokenHeaderTest do
   it 'fails if it receives a JWT header that does not contain a kid found in the jwks' do
     token_header[:kid] = '12345'
 
-    result = run(test, auth_tokens_header_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    result = run(test, auth_token_headers_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
     expect(result.result).to eq('fail')
     expect(entity_result_message.message).to match(/JWKS did not contain a public key with an id of `12345`/)
   end


### PR DESCRIPTION
# Summary
Added functionality to allow clients to submit multiple requests per hook. Updated all the client hook tests accordingly to be able to accept and test multiple requests. Updated all client hook spec tests to work with this new feature.

NOTE: Everything looks good except that for every request that comes in, when the first client hook test loads the requests with the appropriate hook tag for some reason it is grabbing the same request twice, so essentially it seems like every request that comes in is duplicated. I haven't been able to figure out why so I figured I would make this PR so you could take a look and see if the same thing happens for you. 

# Testing Guidance
Run spec tests to make sure they work, and run at least on of the client hook test groups to make sure it runs and produces output as expected.