### PR TITLE
FI-2826: Fix errors produced by testing server and client against one another

### DIFF
--- a/lib/davinci_crd_test_kit/card_responses/propose_alternate_request.json
+++ b/lib/davinci_crd_test_kit/card_responses/propose_alternate_request.json
@@ -15,57 +15,7 @@
   "suggestions": [
     {
       "label": "Replace order with a health assessment first",
-      "actions": [
-        {
-          "type": "create",
-          "description": "Order for patient health assessment",
-          "resource": {
-            "resourceType": "ServiceRequest",
-            "status": "draft",
-            "intent": "order",
-            "category": [
-              {
-                "coding": [
-                  {
-                    "system": "http://snomed.info/sct",
-                    "code": "409063005",
-                    "display": "Counselling"
-                  }
-                ]
-              }
-            ],
-            "code": {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "225885004",
-                  "display": "Health assessment (procedure)"
-                }
-              ]
-            },
-            "subject": {
-              "reference": "http://example.org/fhir/Patient/123"
-            },
-            "occurrenceTiming": {
-              "repeat": {
-                "boundsDuration": {
-                  "value": 3,
-                  "unit": "months",
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mo"
-                },
-                "frequency": 1,
-                "period": 1,
-                "periodUnit": "mo"
-              }
-            },
-            "authoredOn": "2019-02-15",
-            "requester": {
-              "reference": "http://example.org/fhir/PractitionerRole/987"
-            }
-          }
-        }
-      ]
+      "actions": []
     }
   ]
 }

--- a/lib/davinci_crd_test_kit/card_responses/request_form_completion.json
+++ b/lib/davinci_crd_test_kit/card_responses/request_form_completion.json
@@ -14,12 +14,12 @@
   "selectionBehavior": "any",
   "suggestions": [
     {
-      "label" : "Add 'completion of the ABC form' to your task list (possibly for reassignment)",
-      "actions" : [
+      "label": "Add 'completion of the ABC form' to your task list (possibly for reassignment)",
+      "actions": [
         {
-          "type" : "create",
-          "description" : "Add version 2 of the XYZ form to the clinical system's repository (if it doesn't already exist)",
-          "resource" : {
+          "type": "create",
+          "description": "Add version 2 of the XYZ form to the clinical system's repository (if it doesn't already exist)",
+          "resource": {
             "resourceType": "Questionnaire",
             "id": "XYZ",
             "url": "http://example.org/Questionnaire/XYZ",
@@ -178,42 +178,57 @@
           }
         },
         {
-          "type" : "create",
-          "description" : "Add 'Complete ABC form' to the task list",
-          "resource" : {
-            "resourceType" : "Task",
-            "status" : "ready",
-            "intent" : "order",
-            "code" : {
-              "coding" : [
+          "type": "create",
+          "description": "Add 'Complete ABC form' to the task list",
+          "resource": {
+            "resourceType": "Task",
+            "status": "ready",
+            "intent": "order",
+            "code": {
+              "coding": [
                 {
-                  "system" : "http://hl7.org/fhir/uv/sdc/CodeSystem/temp",
-                  "code" : "complete-questionnaire"
+                  "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/temp",
+                  "code": "complete-questionnaire"
                 }
               ]
             },
-            "description" : "Complete XYZ form for local retention",
-            "for" : {
-              "reference" : "http://example.org/fhir/Patient/123"
+            "description": "Complete XYZ form for local retention",
+            "for": {
+              "reference": "http://example.org/fhir/Patient/123"
             },
-            "authoredOn" : "2018-08-09",
-            "input" : [
+            "authoredOn": "2018-08-09",
+            "requester": {
+              "reference": "http://example.org/fhir/Organization/payer"
+            },
+            "input": [
               {
-                "type" : {
-                  "text" : "questionnaire"
+                "type": {
+                  "text": "questionnaire",
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/temp",
+                      "code": "questionnaire"
+                    }
+                  ]
                 },
-                "valueCanonical" : "http://example.org/Questionnaire/XYZ|2"
+                "valueCanonical": "http://example.org/Questionnaire/XYZ"
               },
               {
-                "type" : {
-                  "text" : "afterCompletion"
-                },
-                "valueCodeableConcept" : {
-                  "coding" : [
+                "type": {
+                  "text": "afterCompletion",
+                  "coding": [
                     {
-                      "system" : "http://example.org/fhir/CodeSystem/SomeCodes",
-                      "code" : "987",
-                      "display" : "Local Use"
+                      "system": "http://hl7.org/fhir/us/davinci-crd/CodeSystem/temp",
+                      "code": "after-completion-action"
+                    }
+                  ]
+                },
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/davinci-crd/CodeSystem/temp",
+                      "code": "prior-auth-include",
+                      "display": "Include in prior authorization"
                     }
                   ]
                 }

--- a/lib/davinci_crd_test_kit/client_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/client_hooks_group.rb
@@ -48,6 +48,10 @@ module DaVinciCRDTestKit
         each hook type
         * OPTIONAL: If the incoming hook contains the optional `prefetch` field with valid resources
         * If the client can properly display the cards returned as a result of the hook request
+
+        Note: In order to successfully return a `Coverage Information` system action, a Coverage resource must either be
+        provided in the service request's `prefetch` field, or must be fetchable from the client's FHIR server for
+        the patient provided in the service request.
     DESCRIPTION
     id :crd_client_hooks
 

--- a/lib/davinci_crd_test_kit/client_tests/appointment_book_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/appointment_book_receive_request_test.rb
@@ -23,7 +23,7 @@ module DaVinciCRDTestKit
             response type that will be returned for this hook is the `Coverage Information` card type.
           ),
           type: 'checkbox',
-          default: ['coverage_information'],
+          default: ['coverage_information', 'external_reference', 'instructions'],
           options: {
             list_options: [
               {

--- a/lib/davinci_crd_test_kit/client_tests/encounter_discharge_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/encounter_discharge_receive_request_test.rb
@@ -20,7 +20,7 @@ module DaVinciCRDTestKit
             response type that will be returned for this hook is the `Instructions` card type.
           ),
           type: 'checkbox',
-          default: ['instructions'],
+          default: ['coverage_information', 'external_reference', 'instructions'],
           options: {
             list_options: [
               {

--- a/lib/davinci_crd_test_kit/client_tests/encounter_start_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/encounter_start_receive_request_test.rb
@@ -20,7 +20,7 @@ module DaVinciCRDTestKit
             response type that will be returned for this hook is the `Instructions` card type.
           ),
           type: 'checkbox',
-          default: ['instructions'],
+          default: ['coverage_information', 'external_reference', 'instructions'],
           options: {
             list_options: [
               {

--- a/lib/davinci_crd_test_kit/client_tests/order_dispatch_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/order_dispatch_receive_request_test.rb
@@ -23,7 +23,7 @@ module DaVinciCRDTestKit
             response type that will be returned for this hook is the `Coverage Information` card type.
           ),
           type: 'checkbox',
-          default: ['coverage_information'],
+          default: ['coverage_information', 'external_reference', 'instructions'],
           options: {
             list_options: [
               {

--- a/lib/davinci_crd_test_kit/client_tests/order_select_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/order_select_receive_request_test.rb
@@ -20,7 +20,7 @@ module DaVinciCRDTestKit
             response type that will be returned for this hook is the `Instructions` card type.
           ),
           type: 'checkbox',
-          default: ['instructions'],
+          default: ['coverage_information', 'external_reference', 'instructions'],
           options: {
             list_options: [
               {

--- a/lib/davinci_crd_test_kit/client_tests/order_sign_receive_request_test.rb
+++ b/lib/davinci_crd_test_kit/client_tests/order_sign_receive_request_test.rb
@@ -23,7 +23,7 @@ module DaVinciCRDTestKit
             response type that will be returned for this hook is the `Coverage Information` card type.
           ),
           type: 'checkbox',
-          default: ['coverage_information'],
+          default: ['coverage_information', 'external_reference', 'instructions'],
           options: {
             list_options: [
               {

--- a/lib/davinci_crd_test_kit/mock_service_response.rb
+++ b/lib/davinci_crd_test_kit/mock_service_response.rb
@@ -301,7 +301,11 @@ module DaVinciCRDTestKit
             ),
             FHIR::Extension.new(
               url: 'covered',
-              valueCode: 'conditional'
+              valueCode: 'covered'
+            ),
+            FHIR::Extension.new(
+              url: 'pa-needed',
+              valueCode: 'no-auth'
             ),
             FHIR::Extension.new(
               url: 'date',
@@ -407,14 +411,18 @@ module DaVinciCRDTestKit
       order_resource_id = order_resource.id
 
       card_actions = propose_alternate_request_card['suggestions'][0]['actions']
-      card_actions.append(
+      card_actions.push(
         {
           'type' => 'delete',
           'description' => 'Remove current order until health assessment has been done',
           'resourceId' => ["#{order_resource_type}/#{order_resource_id}"]
+        },
+        {
+          'type' => 'create',
+          'description' => 'Order for patient health assessment',
+          'resource' => order_resource
         }
       )
-      update_service_request(card_actions[0]['resource'], context)
       propose_alternate_request_card
     end
   end

--- a/spec/fixtures/valid_cards.json
+++ b/spec/fixtures/valid_cards.json
@@ -421,23 +421,38 @@
                 "reference": "http://example.org/fhir/Patient/123"
               },
               "authoredOn": "2018-08-09",
+              "requester": {
+                "reference": "http://example.org/fhir/Organization/payer"
+              },
               "input": [
                 {
                   "type": {
-                    "text": "questionnaire"
+                    "text": "questionnaire",
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/uv/sdc/CodeSystem/temp",
+                        "code": "questionnaire"
+                      }
+                    ]
                   },
                   "valueCanonical": "http://example.org/Questionnaire/XYZ"
                 },
                 {
                   "type": {
-                    "text": "afterCompletion"
+                    "text": "afterCompletion",
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/davinci-crd/CodeSystem/temp",
+                        "code": "after-completion-action"
+                      }
+                    ]
                   },
                   "valueCodeableConcept": {
                     "coding": [
                       {
-                        "system": "http://example.org/fhir/CodeSystem/SomeCodes",
-                        "code": "987",
-                        "display": "Local Use"
+                        "system": "http://hl7.org/fhir/us/davinci-crd/CodeSystem/temp",
+                        "code": "prior-auth-include",
+                        "display": "Include in prior authorization"
                       }
                     ]
                   }


### PR DESCRIPTION
# Summary
Fixed problems that were causing the server and client to produce errors when testing against one another. The following fixes are included in this PR:
- Propose Alternate Request validation fix - Creation resource must be the same type as the deleted resource - for simplicity included the same resource that was deleted
- Request Form Completion validation fix - Fixed formatting and included missing fields
-  Coverage Information validation fix - Added missing `pa-needed` extension field
- Make `coverage_information`, `external_reference`, and `instructions` response types the default for selected_response_types input for all hooks

# Testing Guidance
Run the client and server against one another and ensure everything passes as expected. Note: The appointment-book server `All Coverage Information system actions received are valid` test will fail due to a problem with the IG
