### PR TITLE
FI-2829: Add Optional Coverage Info Check to Hooks Not Requiring It

### DIFF
--- a/lib/davinci_crd_test_kit/server_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/server_encounter_discharge_group.rb
@@ -24,6 +24,7 @@ module DaVinciCRDTestKit
       and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
 
       This group includes tests to validate the following CRD response types:
+      - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information) - optional
       - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
       - optional
       - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
@@ -115,6 +116,29 @@ module DaVinciCRDTestKit
            inputs: {
              valid_cards: {
                name: :encounter_discharge_valid_cards
+             }
+           }
+         }
+    test from: :crd_coverage_info_system_action_received,
+         optional: true,
+         config: {
+           inputs: {
+             valid_system_actions: {
+               name: :encounter_discharge_valid_system_actions
+             }
+           },
+           outputs: {
+             coverage_info: {
+               name: :encounter_discharge_coverage_info
+             }
+           }
+         }
+    test from: :crd_coverage_info_system_action_validation,
+         optional: true,
+         config: {
+           inputs: {
+             coverage_info: {
+               name: :encounter_discharge_coverage_info
              }
            }
          }

--- a/lib/davinci_crd_test_kit/server_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/server_encounter_start_group.rb
@@ -24,6 +24,7 @@ module DaVinciCRDTestKit
       and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
 
       This group includes tests to validate the following CRD response types:
+      - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information) - optional
       - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
       - optional
       - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
@@ -115,6 +116,29 @@ module DaVinciCRDTestKit
            inputs: {
              valid_cards: {
                name: :encounter_start_valid_cards
+             }
+           }
+         }
+    test from: :crd_coverage_info_system_action_received,
+         optional: true,
+         config: {
+           inputs: {
+             valid_system_actions: {
+               name: :encounter_start_valid_system_actions
+             }
+           },
+           outputs: {
+             coverage_info: {
+               name: :encounter_start_coverage_info
+             }
+           }
+         }
+    test from: :crd_coverage_info_system_action_validation,
+         optional: true,
+         config: {
+           inputs: {
+             coverage_info: {
+               name: :encounter_start_coverage_info
              }
            }
          }

--- a/lib/davinci_crd_test_kit/server_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/server_order_select_group.rb
@@ -28,6 +28,7 @@ module DaVinciCRDTestKit
       This group includes tests to validate the following CRD response types:
       - [additional orders as companions/prerequisites](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#identify-additional-orders-as-companionsprerequisites-for-current-order)\
       - optional
+      - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information) - optional
       - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
       - optional
       - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
@@ -121,6 +122,29 @@ module DaVinciCRDTestKit
            inputs: {
              valid_cards: {
                name: :order_select_valid_cards
+             }
+           }
+         }
+    test from: :crd_coverage_info_system_action_received,
+         optional: true,
+         config: {
+           inputs: {
+             valid_system_actions: {
+               name: :order_select_valid_system_actions
+             }
+           },
+           outputs: {
+             coverage_info: {
+               name: :order_select_coverage_info
+             }
+           }
+         }
+    test from: :crd_coverage_info_system_action_validation,
+         optional: true,
+         config: {
+           inputs: {
+             coverage_info: {
+               name: :order_select_coverage_info
              }
            }
          }

--- a/lib/davinci_crd_test_kit/server_tests/coverage_information_system_action_received_test.rb
+++ b/lib/davinci_crd_test_kit/server_tests/coverage_information_system_action_received_test.rb
@@ -30,7 +30,10 @@ module DaVinciCRDTestKit
       {
         'appointment-book' => ['Appointment'],
         'order-sign' => shared_resources,
-        'order-dispatch' => shared_resources
+        'order-dispatch' => shared_resources,
+        'order-select' => shared_resources,
+        'encounter-start' => ['Encounter'],
+        'encounter-discharge' => ['Encounter']
       }
     end
 


### PR DESCRIPTION
# Summary

This PR adds an optional coverage information response check to hooks that do not require it. It ensures that valid coverage info returned for these hooks will be included in the across hooks check.

