### PR TITLE
FI-3877: Pin CRD IG version to 2.0.1

### DIFF
--- a/lib/davinci_crd_test_kit/crd_client_suite.rb
+++ b/lib/davinci_crd_test_kit/crd_client_suite.rb
@@ -98,7 +98,7 @@ module DaVinciCRDTestKit
     ]
 
     fhir_resource_validator do
-      igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
+      igs('hl7.fhir.us.davinci-crd#2.0.1')
 
       exclude_message do |message|
         message.message.match?(/\A\S+: \S+: URL value '.*' does not resolve/)

--- a/lib/davinci_crd_test_kit/crd_server_suite.rb
+++ b/lib/davinci_crd_test_kit/crd_server_suite.rb
@@ -94,7 +94,7 @@ module DaVinciCRDTestKit
           title: 'CRD server base URL'
 
     fhir_resource_validator do
-      igs('hl7.fhir.us.davinci-crd', 'hl7.fhir.us.core')
+      igs('hl7.fhir.us.davinci-crd#2.0.1')
 
       exclude_message do |message|
         message.message.match?(/\A\S+: \S+: URL value '.*' does not resolve/)


### PR DESCRIPTION
# Summary

Previously, the CRD test kit was loading the latest version of CRD, which is currently 2.1.0, but the tests were developed against the 2.0.1 version of the IG. This led to validator failures, e.g., because of changes to the appointment profiles.

Now, the client and server test suites for the 2.0.1 CRD IG have been pinned to load the 2.0.1 version of the IG.

# Testing Guidance

Follow the reproduction instructions in [issue 17](https://github.com/inferno-framework/davinci-crd-test-kit/issues/17).  Server tests 3.1.03 and 3.1.11 should now complete without any purple errors.

