### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.1
+* FI-3877: Pin CRD IG version to 2.0.1 by @karlnaden in https://github.com/inferno-framework/davinci-crd-test-kit/pull/18
+
 # 0.11.0
 * **Inferno Core Update:** Bumped to version `0.6.2`.
 * **Ruby Version Update:** Upgraded Ruby to `3.3.6`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    davinci_crd_test_kit (0.11.0)
+    davinci_crd_test_kit (0.11.1)
       inferno_core (~> 0.6.4)
       smart_app_launch_test_kit (~> 0.5.0)
       tls_test_kit (~> 0.3.0)

--- a/lib/davinci_crd_test_kit/version.rb
+++ b/lib/davinci_crd_test_kit/version.rb
@@ -1,4 +1,4 @@
 module DaVinciCRDTestKit
-  VERSION = '0.11.0'.freeze
-  LAST_UPDATED = '2025-02-25'.freeze # TODO: update next release
+  VERSION = '0.11.1'.freeze
+  LAST_UPDATED = '2025-03-18'.freeze # TODO: update next release
 end


### PR DESCRIPTION
## What's Changed
* FI-3877: Pin CRD IG version to 2.0.1 by @karlnaden in https://github.com/inferno-framework/davinci-crd-test-kit/pull/18
