### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.12.0
+## Breaking Change
+This release updates the Da Vinci CRD Test Kit to use AuthInfo rather than
+OAuthCredentials for storing auth information. As a result of this change, any
+test kits which rely on this test kit will need to be updated to use AuthInfo
+rather than OAuthCredentials inputs.
+
+* FI-3746: Transition to use authinfo by @vanessuniq in https://github.com/inferno-framework/davinci-crd-test-kit/pull/20
+
 # 0.11.1
 * FI-3877: Pin CRD IG version to 2.0.1 by @karlnaden in https://github.com/inferno-framework/davinci-crd-test-kit/pull/18
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    davinci_crd_test_kit (0.11.1)
+    davinci_crd_test_kit (0.12.0)
       inferno_core (~> 0.6.4)
       smart_app_launch_test_kit (~> 0.6.0)
       tls_test_kit (~> 0.3.0)

--- a/lib/davinci_crd_test_kit/version.rb
+++ b/lib/davinci_crd_test_kit/version.rb
@@ -1,4 +1,4 @@
 module DaVinciCRDTestKit
-  VERSION = '0.11.1'.freeze
-  LAST_UPDATED = '2025-03-18'.freeze # TODO: update next release
+  VERSION = '0.12.0'.freeze
+  LAST_UPDATED = '2025-03-21'.freeze # TODO: update next release
 end


### PR DESCRIPTION
## Breaking Change
This release updates the Da Vinci CRD Test Kit to use AuthInfo rather than
OAuthCredentials for storing auth information. As a result of this change, any
test kits which rely on this test kit will need to be updated to use AuthInfo
rather than OAuthCredentials inputs.
## What's Changed
* FI-3746: Transition to use authinfo by @vanessuniq in https://github.com/inferno-framework/davinci-crd-test-kit/pull/20

