### PR TITLE
FI-3815 Update Test Kit with new RSpec features

### DIFF
--- a/spec/davinci_crd_test_kit/coverage_information_system_action_across_hooks_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/coverage_information_system_action_across_hooks_validation_test_spec.rb
@@ -17,34 +17,18 @@ RSpec.describe DaVinciCRDTestKit::CoverageInformationSystemActionAcrossHooksVali
   let(:valid_coverage_info_system_action) { JSON.parse(valid_response_body)['systemActions'].first }
   let(:base_url) { 'http://example.com/' }
 
-  # TODO: replace with inferno core version, but need to get inputs
-  # right in the test invocations below first.
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name: name == :coverage_info ? :appointment_book_coverage_info : name,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
-
   before do
     allow_any_instance_of(runnable_within).to receive(:assert_valid_resource).and_return(true)
   end
 
   it 'passes if a valid coverage info system action is present' do
-    run(runnable_within, coverage_info: [valid_coverage_info_system_action].to_json, base_url:)
+    run(runnable_within, appointment_book_coverage_info: [valid_coverage_info_system_action].to_json, base_url:)
     result = run(runnable_across)
     expect(result.result).to eq('pass')
   end
 
   it 'skips if no valid coverage info system action present' do
-    run(runnable_within, coverage_info: [], base_url:)
+    run(runnable_within, appointment_book_coverage_info: [], base_url:)
     result = run(runnable_across)
     expect(result.result).to eq('skip')
     expect(result.result_message).to match(/None of the hooks invoked returned valid Coverage Info system actions/)

--- a/spec/davinci_crd_test_kit/external_reference_card_across_hooks_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/external_reference_card_across_hooks_validation_test_spec.rb
@@ -18,30 +18,14 @@ RSpec.describe DaVinciCRDTestKit::ExternalReferenceCardAcrossHooksValidationTest
   let(:external_ref_card) { cards.find { |card| card['links'].present? } }
   let(:base_url) { 'http://example.com' }
 
-  # TODO: replace with inferno core version, but need to get inputs
-  # right in the test invocations below first.
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name: name == :valid_cards_with_links ? :order_dispatch_valid_cards_with_links : name,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
-
   it 'passes if a valid external reference card is present' do
-    run(runnable_within, valid_cards_with_links: [external_ref_card].to_json, base_url:)
+    run(runnable_within, order_dispatch_valid_cards_with_links: [external_ref_card].to_json, base_url:)
     result = run(runnable_across)
     expect(result.result).to eq('pass')
   end
 
   it 'skips if no external reference card present' do
-    run(runnable_within, valid_cards_with_links: [].to_json, base_url:)
+    run(runnable_within, order_dispatch_valid_cards_with_links: [].to_json, base_url:)
     result = run(runnable_across)
     expect(result.result).to eq('skip')
     expect(result.result_message).to match(/None of the hooks invoked returned an External Reference card./)

--- a/spec/davinci_crd_test_kit/instructions_card_received_across_hooks_test_spec.rb
+++ b/spec/davinci_crd_test_kit/instructions_card_received_across_hooks_test_spec.rb
@@ -18,30 +18,14 @@ RSpec.describe DaVinciCRDTestKit::InstructionsCardReceivedAcrossHooksTest do
   end
   let(:base_url) { 'http://example.com/' }
 
-  # TODO: replace with inferno core version, but need to get inputs
-  # right in the test invocations below first.
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(
-        test_session_id: test_session.id,
-        name: name == :valid_cards ? :order_dispatch_valid_cards : name,
-        value:,
-        type: runnable.config.input_type(name)
-      )
-    end
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
-  end
-
   it 'passes if an Instructions card is present' do
-    run(runnable_within, valid_cards: cards.to_json, base_url:)
+    run(runnable_within, order_dispatch_valid_cards: cards.to_json, base_url:)
     result = run(runnable_across)
     expect(result.result).to eq('pass')
   end
 
   it 'skips if no instructions card present' do
-    run(runnable_within, valid_cards: [].to_json, base_url:)
+    run(runnable_within, order_dispatch_valid_cards: [].to_json, base_url:)
     result = run(runnable_across)
     expect(result.result).to eq('skip')
     expect(result.result_message).to match(/None of the hooks invoked returned a valid Instructions card/)


### PR DESCRIPTION
# Summary

 - Uses `run` for RSpec from inferno_core instead of defining it locally

# Testing Guidance

1. Checkout branch
2. `bundle exec rake`
