### PR TITLE
Add logical model validation for CDS Hooks cards and system actions

### DIFF
--- a/lib/davinci_crd_test_kit/client/endpoints/mocked_card_responses/request_form_completion.json
+++ b/lib/davinci_crd_test_kit/client/endpoints/mocked_card_responses/request_form_completion.json
@@ -24,7 +24,7 @@
             "id": "XYZ",
             "url": "http://example.org/Questionnaire/XYZ",
             "title": "Cancer Quality Forum Questionnaire XYZ",
-            "version": 2,
+            "version": "2",
             "status": "active",
             "subjectType": [
               "Patient"

--- a/lib/davinci_crd_test_kit/client/v2.2.0/verify_response/inferno_response_validation.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.0/verify_response/inferno_response_validation.rb
@@ -42,16 +42,10 @@ module DaVinciCRDTestKit
         "#{response_type} response#{index.present? ? " #{index}" : ''}"
       end
 
-      def valid_cards
-        @valid_cards ||= []
-      end
+      def validate_card_summaries(cards)
+        return unless cards.is_a?(Array)
 
-      def validate_system_actions(system_actions)
-        return if system_actions.nil?
-
-        system_actions.each do |action|
-          action_fields_validation(action, ig_version: 'v220')
-        end
+        cards.each { |card| card_summary_check(card) if card.is_a?(Hash) }
       end
 
       run do
@@ -66,8 +60,7 @@ module DaVinciCRDTestKit
           next unless response_hash['cards'].present? || response_hash['systemActions'].present?
 
           entity_validated = true
-          perform_cards_validation(response_hash['cards'], response_hash['systemActions'].present?, index)
-          validate_system_actions(response_hash['systemActions'])
+          validate_card_summaries(response_hash['cards'])
           perform_cards_logical_model_validation(response_hash['cards'], response_hash['systemActions'], index)
         rescue JSON::ParserError
           next

--- a/lib/davinci_crd_test_kit/client/v2.2.0/verify_response/inferno_response_validation.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.0/verify_response/inferno_response_validation.rb
@@ -1,9 +1,11 @@
 require_relative '../../../cross_suite/cards_validation'
+require_relative '../../../cross_suite/cards_logical_model_validation'
 
 module DaVinciCRDTestKit
   module V220
     class InfernoResponseValidationTest < Inferno::Test
       include CardsValidation
+      include CardsLogicalModelValidation
 
       title 'Inferno CDS Service Response is Conformant'
       description %(
@@ -66,6 +68,7 @@ module DaVinciCRDTestKit
           entity_validated = true
           perform_cards_validation(response_hash['cards'], response_hash['systemActions'].present?, index)
           validate_system_actions(response_hash['systemActions'])
+          perform_cards_logical_model_validation(response_hash['cards'], response_hash['systemActions'], index)
         rescue JSON::ParserError
           next
         end

--- a/lib/davinci_crd_test_kit/cross_suite/cards_logical_model_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_logical_model_validation.rb
@@ -1,0 +1,89 @@
+require_relative 'cards_identification'
+
+module DaVinciCRDTestKit
+  module CardsLogicalModelValidation
+    include DaVinciCRDTestKit::CardsIdentification
+
+    CRD_LOGICAL_MODEL_BASE = 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition'.freeze
+
+    CARD_TYPE_TO_LOGICAL_MODEL = {
+      DaVinciCRDTestKit::CardsIdentification::ADDITIONAL_ORDERS_RESPONSE_TYPE =>
+        'CRDHooksResponse-additionalOrders',
+      DaVinciCRDTestKit::CardsIdentification::CREATE_OR_UPDATE_COVERAGE_RESPONSE_TYPE =>
+        'CRDHooksResponse-adjustCoverage',
+      DaVinciCRDTestKit::CardsIdentification::EXTERNAL_REFERENCE_RESPONSE_TYPE =>
+        'CRDHooksResponse-externalReference',
+      DaVinciCRDTestKit::CardsIdentification::FORM_COMPLETION_RESPONSE_TYPE =>
+        'CRDHooksResponse-formCompletion',
+      DaVinciCRDTestKit::CardsIdentification::INSTRUCTIONS_RESPONSE_TYPE =>
+        'CRDHooksResponse-instructions',
+      DaVinciCRDTestKit::CardsIdentification::LAUNCH_SMART_APP_RESPONSE_TYPE =>
+        'CRDHooksResponse-launchSMART',
+      DaVinciCRDTestKit::CardsIdentification::PROPOSE_ALTERNATIVE_REQUEST_RESPONSE_TYPE =>
+        'CRDHooksResponse-alternateRequest'
+    }.freeze
+
+    ACTION_TYPE_TO_LOGICAL_MODEL = {
+      DaVinciCRDTestKit::CardsIdentification::COVERAGE_INFORMATION_RESPONSE_TYPE =>
+        'CRDHooksResponse-coverageInformation',
+      DaVinciCRDTestKit::CardsIdentification::CREATE_OR_UPDATE_COVERAGE_RESPONSE_TYPE =>
+        'CRDHooksResponse-adjustCoverage',
+      DaVinciCRDTestKit::CardsIdentification::FORM_COMPLETION_RESPONSE_TYPE =>
+        'CRDHooksResponse-formCompletion'
+    }.freeze
+
+    def logical_model_url(profile_name)
+      "#{CRD_LOGICAL_MODEL_BASE}/#{profile_name}"
+    end
+
+    def perform_cards_logical_model_validation(cards, system_actions, response_index = 0)
+      Array(cards).each_with_index do |card, card_index|
+        validate_card_against_logical_model(card, response_index, card_index)
+      end
+
+      Array(system_actions).each_with_index do |action, action_index|
+        validate_system_action_against_logical_model(action, response_index, action_index)
+      end
+    end
+
+    def validate_card_against_logical_model(card, response_index, card_index)
+      return unless card.is_a?(Hash)
+
+      card_type = identify_card_type(card)
+      label = logical_model_entity_label(response_index, card_index, 'card')
+
+      profile_name = CARD_TYPE_TO_LOGICAL_MODEL[card_type]
+      unless profile_name
+        add_message('warning',
+                    "#{label} could not be categorized as a known CRD response type; " \
+                    'skipping logical model validation.')
+        return
+      end
+
+      conforms_to_logical_model?({ 'cards' => [card] }, logical_model_url(profile_name),
+                                 message_prefix: "#{label} (#{card_type}): ")
+    end
+
+    def validate_system_action_against_logical_model(action, response_index, action_index)
+      return unless action.is_a?(Hash)
+
+      action_type = identify_action_type(action)
+      label = logical_model_entity_label(response_index, action_index, 'systemAction')
+
+      profile_name = ACTION_TYPE_TO_LOGICAL_MODEL[action_type]
+      unless profile_name
+        add_message('warning',
+                    "#{label} could not be categorized as a known CRD response type; " \
+                    'skipping logical model validation.')
+        return
+      end
+
+      conforms_to_logical_model?({ 'systemActions' => [action] }, logical_model_url(profile_name),
+                                 message_prefix: "#{label} (#{action_type}): ")
+    end
+
+    def logical_model_entity_label(response_index, entity_index, kind)
+      "Server response #{response_index + 1} #{kind} #{entity_index + 1}"
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/cross_suite/cards_logical_model_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_logical_model_validation.rb
@@ -5,6 +5,7 @@ module DaVinciCRDTestKit
     include DaVinciCRDTestKit::CardsIdentification
 
     CRD_LOGICAL_MODEL_BASE = 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition'.freeze
+    CRD_RESPONSE_BASE_LOGICAL_MODEL = 'CRDHooksResponseBase'.freeze
 
     CARD_TYPE_TO_LOGICAL_MODEL = {
       DaVinciCRDTestKit::CardsIdentification::ADDITIONAL_ORDERS_RESPONSE_TYPE =>
@@ -37,49 +38,57 @@ module DaVinciCRDTestKit
     end
 
     def perform_cards_logical_model_validation(cards, system_actions, response_index = 0)
-      Array(cards).each_with_index do |card, card_index|
-        validate_card_against_logical_model(card, response_index, card_index)
+      if cards.is_a?(Array)
+        cards.each_with_index do |card, card_index|
+          validate_card_against_logical_model(card, response_index, card_index)
+        end
       end
 
-      Array(system_actions).each_with_index do |action, action_index|
+      return unless system_actions.is_a?(Array)
+
+      system_actions.each_with_index do |action, action_index|
         validate_system_action_against_logical_model(action, response_index, action_index)
       end
     end
 
     def validate_card_against_logical_model(card, response_index, card_index)
-      return unless card.is_a?(Hash)
+      label = logical_model_entity_label(response_index, card_index, 'card')
+      unless card.is_a?(Hash)
+        add_message('error', "#{label} is not a JSON object; skipping logical model validation.")
+        return
+      end
 
       card_type = identify_card_type(card)
-      label = logical_model_entity_label(response_index, card_index, 'card')
-
       profile_name = CARD_TYPE_TO_LOGICAL_MODEL[card_type]
       unless profile_name
         add_message('warning',
                     "#{label} could not be categorized as a known CRD response type; " \
-                    'skipping logical model validation.')
-        return
+                    'validating against the base CRD response logical model.')
+        profile_name = CRD_RESPONSE_BASE_LOGICAL_MODEL
       end
 
       conforms_to_logical_model?({ 'cards' => [card] }, logical_model_url(profile_name),
-                                 message_prefix: "#{label} (#{card_type}): ")
+                                 message_prefix: "#{label} (#{card_type || 'uncategorized'}): ")
     end
 
     def validate_system_action_against_logical_model(action, response_index, action_index)
-      return unless action.is_a?(Hash)
+      label = logical_model_entity_label(response_index, action_index, 'systemAction')
+      unless action.is_a?(Hash)
+        add_message('error', "#{label} is not a JSON object; skipping logical model validation.")
+        return
+      end
 
       action_type = identify_action_type(action)
-      label = logical_model_entity_label(response_index, action_index, 'systemAction')
-
       profile_name = ACTION_TYPE_TO_LOGICAL_MODEL[action_type]
       unless profile_name
         add_message('warning',
                     "#{label} could not be categorized as a known CRD response type; " \
-                    'skipping logical model validation.')
-        return
+                    'validating against the base CRD response logical model.')
+        profile_name = CRD_RESPONSE_BASE_LOGICAL_MODEL
       end
 
       conforms_to_logical_model?({ 'systemActions' => [action] }, logical_model_url(profile_name),
-                                 message_prefix: "#{label} (#{action_type}): ")
+                                 message_prefix: "#{label} (#{action_type || 'uncategorized'}): ")
     end
 
     def logical_model_entity_label(response_index, entity_index, kind)

--- a/lib/davinci_crd_test_kit/server/v2.2.0/verify_response/service_response_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/verify_response/service_response_validation_test.rb
@@ -1,10 +1,12 @@
 require_relative '../../../cross_suite/cards_validation'
+require_relative '../../../cross_suite/cards_logical_model_validation'
 require_relative '../../server_hook_helper'
 
 module DaVinciCRDTestKit
   module V220
     class ServiceResponseValidationTest < Inferno::Test
       include DaVinciCRDTestKit::CardsValidation
+      include DaVinciCRDTestKit::CardsLogicalModelValidation
       include DaVinciCRDTestKit::ServerHookHelper
 
       title 'All service responses contain valid cards and optional systemActions'
@@ -69,6 +71,8 @@ module DaVinciCRDTestKit
           perform_cards_validation(service_response['cards'], service_response['systemActions'].present?, index)
 
           perform_system_actions_validation(service_response['systemActions'], index)
+
+          perform_cards_logical_model_validation(service_response['cards'], service_response['systemActions'], index)
         rescue JSON::ParserError
           add_message('error', "Invalid JSON: server response #{index + 1} is not a valid JSON.")
         end

--- a/spec/davinci_crd_test_kit/cards_logical_model_validation_spec.rb
+++ b/spec/davinci_crd_test_kit/cards_logical_model_validation_spec.rb
@@ -98,7 +98,16 @@ RSpec.describe DaVinciCRDTestKit::CardsLogicalModelValidation do
         .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-formCompletion')
     end
 
-    it 'records a warning and skips validation for uncategorized cards' do
+    it 'records an error and skips validation when a card is not a JSON object' do
+      module_instance.validate_card_against_logical_model('not a card', 0, 0)
+
+      expect(module_instance.conforms_calls).to be_empty
+      expect(module_instance.messages).to include(
+        hash_including(type: 'error', message: a_string_including('is not a JSON object'))
+      )
+    end
+
+    it 'records a warning and validates uncategorized cards against the base logical model' do
       unknown_card = {
         'summary' => 'unknown', 'indicator' => 'info', 'source' => { 'label' => 'x' },
         'links' => [{ 'type' => 'smart' }, { 'type' => 'absolute' }]
@@ -106,7 +115,9 @@ RSpec.describe DaVinciCRDTestKit::CardsLogicalModelValidation do
 
       module_instance.validate_card_against_logical_model(unknown_card, 0, 0)
 
-      expect(module_instance.conforms_calls).to be_empty
+      expect(module_instance.conforms_calls.length).to eq(1)
+      expect(module_instance.conforms_calls.first[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponseBase')
       expect(module_instance.messages).to include(
         hash_including(type: 'warning', message: a_string_including('could not be categorized'))
       )
@@ -126,13 +137,24 @@ RSpec.describe DaVinciCRDTestKit::CardsLogicalModelValidation do
       expect(call[:message_prefix]).to include('coverage_information')
     end
 
-    it 'records a warning and skips validation for uncategorized actions' do
+    it 'records an error and skips validation when a system action is not a JSON object' do
+      module_instance.validate_system_action_against_logical_model('not an action', 0, 0)
+
+      expect(module_instance.conforms_calls).to be_empty
+      expect(module_instance.messages).to include(
+        hash_including(type: 'error', message: a_string_including('is not a JSON object'))
+      )
+    end
+
+    it 'records a warning and validates uncategorized actions against the base logical model' do
       unknown_action = { 'type' => 'update', 'description' => 'x',
                          'resource' => { 'resourceType' => 'Patient', 'id' => 'p' } }
 
       module_instance.validate_system_action_against_logical_model(unknown_action, 0, 0)
 
-      expect(module_instance.conforms_calls).to be_empty
+      expect(module_instance.conforms_calls.length).to eq(1)
+      expect(module_instance.conforms_calls.first[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponseBase')
       expect(module_instance.messages).to include(
         hash_including(type: 'warning', message: a_string_including('could not be categorized'))
       )

--- a/spec/davinci_crd_test_kit/cards_logical_model_validation_spec.rb
+++ b/spec/davinci_crd_test_kit/cards_logical_model_validation_spec.rb
@@ -1,0 +1,164 @@
+require_relative '../../lib/davinci_crd_test_kit/cross_suite/cards_logical_model_validation'
+
+RSpec.describe DaVinciCRDTestKit::CardsLogicalModelValidation do
+  let(:module_instance) do
+    Class.new do
+      include DaVinciCRDTestKit::CardsLogicalModelValidation
+
+      attr_reader :messages, :conforms_calls
+
+      def initialize
+        @messages = []
+        @conforms_calls = []
+      end
+
+      def add_message(type, message)
+        @messages << { type:, message: }
+      end
+
+      def conforms_to_logical_model?(object, url, message_prefix: '')
+        @conforms_calls << { object:, url:, message_prefix: }
+        true
+      end
+
+      def scratch
+        @scratch ||= {}
+      end
+    end.new
+  end
+  let(:additional_orders_card) { load_mock('companions_prerequisites.json') }
+  let(:external_reference_card) { load_mock('external_reference.json') }
+  let(:instructions_card) { load_mock('instructions.json') }
+  let(:launch_smart_app_card) { load_mock('launch_smart_app.json') }
+  let(:form_completion_card) { load_mock('request_form_completion.json') }
+  let(:coverage_information_action) do
+    JSON.parse(<<~JSON)
+      {
+        "type": "update",
+        "description": "add coverage-information extension",
+        "resource": {
+          "resourceType": "ServiceRequest",
+          "id": "existingSR",
+          "extension": [{
+            "url": "http://hl7.org/fhir/us/davinci-crd/StructureDefinition/ext-coverage-information",
+            "valueString": "sub-extensions elided"
+          }],
+          "status": "details elided"
+        }
+      }
+    JSON
+  end
+
+  let(:mocked_card_responses_dir) do
+    File.join(__dir__, '..', '..', 'lib', 'davinci_crd_test_kit', 'client', 'endpoints', 'mocked_card_responses')
+  end
+
+  def load_mock(name)
+    JSON.parse(File.read(File.join(mocked_card_responses_dir, name)))
+  end
+
+  describe '#validate_card_against_logical_model' do
+    it 'wraps an external reference card in a CDS Hooks response and validates it against the logical model' do
+      module_instance.validate_card_against_logical_model(external_reference_card, 0, 0)
+
+      expect(module_instance.conforms_calls.length).to eq(1)
+      call = module_instance.conforms_calls.first
+      expect(call[:object]).to eq('cards' => [external_reference_card])
+      expect(call[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-externalReference')
+      expect(call[:message_prefix]).to include('Server response 1 card 1')
+      expect(call[:message_prefix]).to include('external_reference')
+    end
+
+    it 'uses the additional orders logical model for additional-orders cards' do
+      module_instance.validate_card_against_logical_model(additional_orders_card, 0, 0)
+
+      expect(module_instance.conforms_calls.last[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-additionalOrders')
+    end
+
+    it 'uses the instructions logical model for instructions cards' do
+      module_instance.validate_card_against_logical_model(instructions_card, 0, 0)
+
+      expect(module_instance.conforms_calls.last[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-instructions')
+    end
+
+    it 'uses the launchSMART logical model for launch SMART app cards' do
+      module_instance.validate_card_against_logical_model(launch_smart_app_card, 0, 0)
+
+      expect(module_instance.conforms_calls.last[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-launchSMART')
+    end
+
+    it 'uses the formCompletion logical model for form completion cards' do
+      module_instance.validate_card_against_logical_model(form_completion_card, 0, 0)
+
+      expect(module_instance.conforms_calls.last[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-formCompletion')
+    end
+
+    it 'records a warning and skips validation for uncategorized cards' do
+      unknown_card = {
+        'summary' => 'unknown', 'indicator' => 'info', 'source' => { 'label' => 'x' },
+        'links' => [{ 'type' => 'smart' }, { 'type' => 'absolute' }]
+      }
+
+      module_instance.validate_card_against_logical_model(unknown_card, 0, 0)
+
+      expect(module_instance.conforms_calls).to be_empty
+      expect(module_instance.messages).to include(
+        hash_including(type: 'warning', message: a_string_including('could not be categorized'))
+      )
+    end
+  end
+
+  describe '#validate_system_action_against_logical_model' do
+    it 'wraps the action in a CDS Hooks response and uses the coverageInformation logical model' do
+      module_instance.validate_system_action_against_logical_model(coverage_information_action, 2, 1)
+
+      expect(module_instance.conforms_calls.length).to eq(1)
+      call = module_instance.conforms_calls.first
+      expect(call[:object]).to eq('systemActions' => [coverage_information_action])
+      expect(call[:url])
+        .to eq('http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-coverageInformation')
+      expect(call[:message_prefix]).to include('Server response 3 systemAction 2')
+      expect(call[:message_prefix]).to include('coverage_information')
+    end
+
+    it 'records a warning and skips validation for uncategorized actions' do
+      unknown_action = { 'type' => 'update', 'description' => 'x',
+                         'resource' => { 'resourceType' => 'Patient', 'id' => 'p' } }
+
+      module_instance.validate_system_action_against_logical_model(unknown_action, 0, 0)
+
+      expect(module_instance.conforms_calls).to be_empty
+      expect(module_instance.messages).to include(
+        hash_including(type: 'warning', message: a_string_including('could not be categorized'))
+      )
+    end
+  end
+
+  describe '#perform_cards_logical_model_validation' do
+    it 'validates each card and each system action independently' do
+      module_instance.perform_cards_logical_model_validation(
+        [external_reference_card, instructions_card],
+        [coverage_information_action],
+        0
+      )
+
+      expect(module_instance.conforms_calls.length).to eq(3)
+      urls = module_instance.conforms_calls.map { |c| c[:url] }
+      expect(urls).to include(
+        'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-externalReference',
+        'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-instructions',
+        'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/CRDHooksResponse-coverageInformation'
+      )
+    end
+
+    it 'handles missing cards and systemActions gracefully' do
+      expect { module_instance.perform_cards_logical_model_validation(nil, nil, 0) }.to_not raise_error
+      expect(module_instance.conforms_calls).to be_empty
+    end
+  end
+end

--- a/spec/davinci_crd_test_kit/mock_service_response_spec.rb
+++ b/spec/davinci_crd_test_kit/mock_service_response_spec.rb
@@ -83,5 +83,13 @@ RSpec.describe DaVinciCRDTestKit::MockServiceResponse do
       expect(task['resourceType']).to eq('Task')
       expect(task['input'].size).to eq(1)
     end
+
+    it 'form completion questionnaire version is a string' do
+      response = mocked_response_creator_v220.build_mock_hook_response
+      questionnaire = response.dig('cards', 0, 'suggestions', 0, 'actions', 0, 'resource')
+
+      expect(questionnaire['resourceType']).to eq('Questionnaire')
+      expect(questionnaire['version']).to eq('2')
+    end
   end
 end

--- a/spec/davinci_crd_test_kit/v2.2.0/inferno_response_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.0/inferno_response_validation_test_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe DaVinciCRDTestKit::V220::InfernoResponseValidationTest do
+  let(:suite_id) { 'crd_client' }
+  let(:order_sign_test) do
+    Class.new(described_class) do
+      config({ options: { hook_name: DaVinciCRDTestKit::ORDER_SIGN_TAG } })
+
+      def conforms_to_logical_model?(*_args, **_kwargs)
+        true
+      end
+    end
+  end
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
+
+  def store_request(response_body, tags, status: 200)
+    repo_create(
+      :request,
+      direction: 'incoming',
+      test_session_id: test_session.id,
+      result:,
+      response_body:,
+      tags:,
+      status:
+    )
+  end
+
+  def first_error_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [order_sign_test])
+      .first
+      .messages.select { |message| message.type == 'error' }
+      .first
+  end
+
+  it 'fails if a card summary is more than 140 characters' do
+    cards = [{ summary: SecureRandom.alphanumeric(150), indicator: 'info', source: { label: 'Inferno' } }]
+    store_request({ cards: }.to_json, [DaVinciCRDTestKit::ORDER_SIGN_TAG])
+
+    result = run(order_sign_test)
+
+    expect(result.result).to eq('fail')
+    expect(first_error_message.message).to match(/`summary` is over the 140-character limit/)
+  end
+end


### PR DESCRIPTION
### Summary

This PR introduces FHIR logical model validation for CRD v2.2.0 responses.

Each `card` and `systemAction` is:

- Identified using existing `CardsIdentification`
- Wrapped into a minimal CDS Hooks response
- Validated against corresponding CRD logical models (`CRDHooksResponse-*`)

### Background

CRD v2.2.x defines logical models for response validation.

However:

- Logical models cannot be applied directly at card level
- Full response validation is not supported by tooling

Solution:

- Validate each entity individually by wrapping it into a minimal response.

### Implementation Details

**New Module**

- `CardsLogicalModelValidation`

**Key Behavior**

- Maps card/action => logical model
- Wraps entity:

```
{ "cards" => [card] }
{ 'systemActions' => [action] }
```

**Calls:**

- conforms_to_logical_model?

**Integration Points (v2.2.0 only**)

- `ServiceResponseValidationTest`
- `InfernoResponseValidationTest`

### Scope

**Included**

- Logical model validation for v2.2.0
- Per-entity validation (cards + systemActions)

**Excluded**

- v2.0.1 (unchanged)
- Fixture updates
- Error deduplication

### Testing

**Unit Tests**

- bundle exec rspec

**Lint**

- bundle exec rubocop

### UI Validation

**Positive Flow**

- Run CRD Server v2.2.0 Test Suite
- Navigate to: Hook Tests => Verify Responses
- Run: crd_v220_service_response_validation

Expected:

- Validation runs successfully
- No logical model errors for compliant responses

**Negative Flow**

Using existing fixtures (no modification):

Expected:

- Logical model validation errors appear
- Errors include:
  - Missing required fields
  - Invalid resource types
  - Value set violations
  - Disallowed elements

Example:

Server response 1 card 1 (instructions): <FHIR validation error>

### Important Note

Logical model validation introduces stricter checks.

As a result:

- Some existing fixtures may produce validation errors
- These errors reflect non-compliance with CRD v2.2.x logical models

This PR does **not modify fixtures** and focuses only on validation logic.