### PR TITLE
ID-80: Add CRD 2.2 coverage-info configuration support

### DIFF
--- a/lib/davinci_crd_test_kit/client/endpoints/hook_request_endpoint.rb
+++ b/lib/davinci_crd_test_kit/client/endpoints/hook_request_endpoint.rb
@@ -1,6 +1,7 @@
 require_relative 'gather_response_generation_data'
 require_relative 'mock_service_response'
 require_relative 'custom_service_response'
+require_relative '../../cross_suite/cards_identification'
 require_relative '../../cross_suite/tags'
 
 module DaVinciCRDTestKit
@@ -8,6 +9,7 @@ module DaVinciCRDTestKit
     include DaVinciCRDTestKit::MockServiceResponse
     include DaVinciCRDTestKit::GatherResponseGenerationData
     include DaVinciCRDTestKit::CustomServiceResponse
+    include DaVinciCRDTestKit::CardsIdentification
 
     AVAILABLE_HOOKS = [
       'appointment-book',
@@ -68,7 +70,7 @@ module DaVinciCRDTestKit
           send(:"gather_#{hook_name.gsub('-', '_')}_data")
           request_coverage
         end
-        response_body = hook_response
+        response_body = apply_hook_configuration(hook_response)
         if response_body.present?
           response.body = response_body.to_json
           response.headers.merge!({ 'Content-Type' => 'application/json', 'Access-Control-Allow-Origin' => '*' })
@@ -92,6 +94,24 @@ module DaVinciCRDTestKit
     rescue StandardError => e
       error_response("Inferno failed to generate a response: #{e.message} at #{e.backtrace.first}", code: 500)
       nil
+    end
+
+    def apply_hook_configuration(response_body)
+      return response_body unless response_body.present? && coverage_info_disabled?
+
+      cards = response_body['cards']
+      response_body['cards'] = cards.reject { |card| coverage_info_card_type?(card) } if cards.is_a?(Array)
+
+      system_actions = response_body['systemActions']
+      if system_actions.is_a?(Array)
+        response_body['systemActions'] = system_actions.reject { |action| coverage_info_system_action_type?(action) }
+      end
+
+      response_body
+    end
+
+    def coverage_info_disabled?
+      request_body.dig('extension', 'davinci-crd.configuration', COVERAGE_INFO_CONFIGURATION_CODE) == false
     end
 
     def hook_instance_already_used?

--- a/lib/davinci_crd_test_kit/client/v2.2.0/cds-services-v220.json
+++ b/lib/davinci_crd_test_kit/client/v2.2.0/cds-services-v220.json
@@ -24,6 +24,15 @@
         "davinci-crd.version" : [
           "2.2",
           "2.0"
+        ],
+        "davinci-crd.configuration-options" : [
+          {
+            "code" : "coverage-info",
+            "type" : "boolean",
+            "name" : "Coverage Information",
+            "description" : "Information related to the patient's coverage, including whether a service is covered, requires prior authorization, is approved without seeking prior authorization, and/or requires additional documentation or data collection",
+            "default" : true
+          }
         ]
       }
     },
@@ -45,6 +54,15 @@
         "davinci-crd.version" : [
           "2.2",
           "2.0"
+        ],
+        "davinci-crd.configuration-options" : [
+          {
+            "code" : "coverage-info",
+            "type" : "boolean",
+            "name" : "Coverage Information",
+            "description" : "Information related to the patient's coverage, including whether a service is covered, requires prior authorization, is approved without seeking prior authorization, and/or requires additional documentation or data collection",
+            "default" : true
+          }
         ]
       }
     },
@@ -66,6 +84,15 @@
         "davinci-crd.version" : [
           "2.2",
           "2.0"
+        ],
+        "davinci-crd.configuration-options" : [
+          {
+            "code" : "coverage-info",
+            "type" : "boolean",
+            "name" : "Coverage Information",
+            "description" : "Information related to the patient's coverage, including whether a service is covered, requires prior authorization, is approved without seeking prior authorization, and/or requires additional documentation or data collection",
+            "default" : true
+          }
         ]
       }
     },
@@ -95,6 +122,15 @@
         "davinci-crd.version" : [
           "2.2",
           "2.0"
+        ],
+        "davinci-crd.configuration-options" : [
+          {
+            "code" : "coverage-info",
+            "type" : "boolean",
+            "name" : "Coverage Information",
+            "description" : "Information related to the patient's coverage, including whether a service is covered, requires prior authorization, is approved without seeking prior authorization, and/or requires additional documentation or data collection",
+            "default" : true
+          }
         ]
       }
     },
@@ -118,6 +154,15 @@
         "davinci-crd.version" : [
           "2.2",
           "2.0"
+        ],
+        "davinci-crd.configuration-options" : [
+          {
+            "code" : "coverage-info",
+            "type" : "boolean",
+            "name" : "Coverage Information",
+            "description" : "Information related to the patient's coverage, including whether a service is covered, requires prior authorization, is approved without seeking prior authorization, and/or requires additional documentation or data collection",
+            "default" : true
+          }
         ]
       }
     },
@@ -141,6 +186,15 @@
         "davinci-crd.version" : [
           "2.2",
           "2.0"
+        ],
+        "davinci-crd.configuration-options" : [
+          {
+            "code" : "coverage-info",
+            "type" : "boolean",
+            "name" : "Coverage Information",
+            "description" : "Information related to the patient's coverage, including whether a service is covered, requires prior authorization, is approved without seeking prior authorization, and/or requires additional documentation or data collection",
+            "default" : true
+          }
         ]
       }
     }

--- a/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
@@ -65,6 +65,46 @@ module DaVinciCRDTestKit
       [COVERAGE_INFORMATION_RESPONSE_TYPE, FORM_COMPLETION_RESPONSE_TYPE].include?(identify_action_type(action))
     end
 
+    def coverage_info_content(response_body)
+      return [[], []] unless response_body.is_a?(Hash)
+
+      cards =
+        if response_body['cards'].is_a?(Array)
+          response_body['cards'].select { |card| coverage_info_card_type?(card) }
+        else
+          []
+        end
+      actions =
+        if response_body['systemActions'].is_a?(Array)
+          response_body['systemActions'].select { |action| coverage_info_system_action_type?(action) }
+        else
+          []
+        end
+
+      [cards, actions]
+    end
+
+    def coverage_info_response?(response_body)
+      cards, actions = coverage_info_content(response_body)
+
+      cards.present? || actions.present?
+    end
+
+    def coverage_info_configuration_disabled?(request_body)
+      request_body.is_a?(Hash) &&
+        request_body.dig('extension', 'davinci-crd.configuration', COVERAGE_INFO_CONFIGURATION_CODE) == false
+    end
+
+    def disable_coverage_info_configuration!(request_body)
+      request_body['extension'] = {} unless request_body['extension'].is_a?(Hash)
+      unless request_body['extension']['davinci-crd.configuration'].is_a?(Hash)
+        request_body['extension']['davinci-crd.configuration'] = {}
+      end
+      request_body['extension']['davinci-crd.configuration'][COVERAGE_INFO_CONFIGURATION_CODE] = false
+
+      request_body
+    end
+
     def additional_orders_response_type?(card, expected_resource_types: ADDITIONAL_ORDERS_EXPECTED_RESOURCE_TYPES)
       card['suggestions']&.all? do |suggestion|
         actions = suggestion['actions']

--- a/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
@@ -16,6 +16,7 @@ module DaVinciCRDTestKit
     INSTRUCTIONS_RESPONSE_TYPE = 'instructions'.freeze
     LAUNCH_SMART_APP_RESPONSE_TYPE = 'launch_smart_app'.freeze
     PROPOSE_ALTERNATIVE_REQUEST_RESPONSE_TYPE = 'propose_alternate_request'.freeze
+    COVERAGE_INFO_CONFIGURATION_CODE = 'coverage-info'.freeze
 
     ADDITIONAL_ORDERS_EXPECTED_RESOURCE_TYPES = %w[
       CommunicationRequest Device DeviceRequest Medication
@@ -51,6 +52,19 @@ module DaVinciCRDTestKit
       nil
     end
 
+    def coverage_info_card_type?(card)
+      return false unless card.respond_to?(:dig)
+
+      card.dig('source', 'type') == COVERAGE_INFO_CONFIGURATION_CODE ||
+        card.dig('source', 'topic', 'code') == COVERAGE_INFO_CONFIGURATION_CODE
+    end
+
+    def coverage_info_system_action_type?(action)
+      return false unless action.respond_to?(:[])
+
+      [COVERAGE_INFORMATION_RESPONSE_TYPE, FORM_COMPLETION_RESPONSE_TYPE].include?(identify_action_type(action))
+    end
+
     def additional_orders_response_type?(card, expected_resource_types: ADDITIONAL_ORDERS_EXPECTED_RESOURCE_TYPES)
       card['suggestions']&.all? do |suggestion|
         actions = suggestion['actions']
@@ -62,7 +76,23 @@ module DaVinciCRDTestKit
     end
 
     def coverage_information_response_type?(action)
-      action.dig('resource', 'extension')&.any? { |extension| extension['url'] == COVERAGE_INFO_EXT_URL }
+      return false unless action.respond_to?(:[])
+
+      extensions =
+        if action['resource'].respond_to?(:extension)
+          action['resource'].extension
+        else
+          action.dig('resource', 'extension')
+        end
+
+      extensions&.any? { |extension| extension_url(extension) == COVERAGE_INFO_EXT_URL }
+    end
+
+    def extension_url(extension)
+      return extension.url if extension.respond_to?(:url)
+      return extension['url'] if extension.respond_to?(:[])
+
+      nil
     end
 
     def create_or_update_coverage_card_response_type?(card)

--- a/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
+++ b/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
@@ -2,16 +2,21 @@
 
 require_relative '../../cross_suite/tags'
 require_relative '../../cross_suite/base_urls'
+require_relative '../../cross_suite/cards_identification'
+require_relative '../endpoints/mock_ehr/fhir_request_handler'
+require_relative '../server_base_urls'
 
 module DaVinciCRDTestKit
   module Jobs
     class InvokeHook
       include Sidekiq::Job
+      include DaVinciCRDTestKit::CardsIdentification
 
       sidekiq_options retry: false
 
       def perform(test_session_id, request_bodies, service_endpoint, inferno_base_url, jwks_kid,
-                  encryption_method, request_tag, continuation_url, failure_url, acknowledge_before_continuing)
+                  encryption_method, request_tag, continuation_url, failure_url, acknowledge_before_continuing,
+                  coverage_info_configuration_supported)
         @test_session_id = test_session_id
         @service_endpoint = service_endpoint
         @inferno_base_url = inferno_base_url
@@ -21,6 +26,7 @@ module DaVinciCRDTestKit
         @continuation_url = continuation_url
         @failure_url = failure_url
         @acknowledge_before_continuing = acknowledge_before_continuing
+        @coverage_info_configuration_supported = coverage_info_configuration_supported
 
         perform_hook_invocations(request_bodies)
       end
@@ -31,7 +37,9 @@ module DaVinciCRDTestKit
         request_bodies.each do |request|
           break unless test_waiting?
 
-          send_hook_invocation(request.to_json)
+          request_body = prepare_hook_request(request)
+          response = send_hook_invocation(request_body.to_json)
+          send_coverage_info_configuration_invocation(request_body, response)
         end
         return unless test_waiting?
 
@@ -61,6 +69,10 @@ module DaVinciCRDTestKit
         @service_connection ||= Faraday.new(url: @service_endpoint, request: { open_timeout: 30 })
       end
 
+      def fhir_url
+        @inferno_base_url + FHIR_ROUTE
+      end
+
       def test_done?
         test_runs_repo.status_for_test_run(test_run_id) == 'done'
       end
@@ -75,6 +87,22 @@ module DaVinciCRDTestKit
         results_repo.find_waiting_result(test_run_id:).present?
       end
 
+      def prepare_hook_request(parsed_request)
+        parsed_request['hookInstance'] = SecureRandom.uuid
+        parsed_request['fhirServer'] = fhir_url
+        update_simulated_server_token(parsed_request)
+        parsed_request
+      end
+
+      def update_simulated_server_token(parsed_request)
+        parsed_request['fhirAuthorization'] = {} if parsed_request['fhirAuthorization'].nil?
+        fhir_authorization = parsed_request['fhirAuthorization']
+
+        fhir_authorization['expires_in'] = 300 unless fhir_authorization['expires_in'].present?
+        fhir_authorization['access_token'] =
+          MockEHR::FHIRRequestHandler.session_id_to_token(@test_session_id, fhir_authorization['expires_in'].to_i / 60)
+      end
+
       def send_hook_invocation(request_body)
         token = JwtHelper.build(
           aud: @service_endpoint,
@@ -87,6 +115,24 @@ module DaVinciCRDTestKit
         response = invoke_hook(request_body, headers)
         persist_hook_request(response, [@request_tag], headers)
         response
+      end
+
+      def send_coverage_info_configuration_invocation(request_body, response)
+        return unless @coverage_info_configuration_supported
+        return unless response.status == 200
+        return unless coverage_info_response?(parsed_response_body(response))
+        return unless test_waiting?
+
+        configured_request_body = JSON.parse(request_body.to_json)
+        prepare_hook_request(configured_request_body)
+        disable_coverage_info_configuration!(configured_request_body)
+        send_hook_invocation(configured_request_body.to_json)
+      end
+
+      def parsed_response_body(response)
+        JSON.parse(response.env.response_body.to_s)
+      rescue JSON::ParserError, TypeError
+        nil
       end
 
       def invoke_hook(request_body, headers)

--- a/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
+++ b/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
@@ -11,6 +11,7 @@ module DaVinciCRDTestKit
     class InvokeHook
       include Sidekiq::Job
       include DaVinciCRDTestKit::CardsIdentification
+      include DaVinciCRDTestKit::ServerBaseURLs
 
       sidekiq_options retry: false
 
@@ -69,10 +70,6 @@ module DaVinciCRDTestKit
         @service_connection ||= Faraday.new(url: @service_endpoint, request: { open_timeout: 30 })
       end
 
-      def fhir_url
-        @inferno_base_url + FHIR_ROUTE
-      end
-
       def test_done?
         test_runs_repo.status_for_test_run(test_run_id) == 'done'
       end
@@ -119,6 +116,7 @@ module DaVinciCRDTestKit
 
       def send_coverage_info_configuration_invocation(request_body, response)
         return unless @coverage_info_configuration_supported
+        return if @coverage_info_configuration_invoked
         return unless response.status == 200
         return unless coverage_info_response?(parsed_response_body(response))
         return unless test_waiting?
@@ -127,6 +125,7 @@ module DaVinciCRDTestKit
         prepare_hook_request(configured_request_body)
         disable_coverage_info_configuration!(configured_request_body)
         send_hook_invocation(configured_request_body.to_json)
+        @coverage_info_configuration_invoked = true
       end
 
       def parsed_response_body(response)

--- a/lib/davinci_crd_test_kit/server/server_abstract_invoke_hook_test.rb
+++ b/lib/davinci_crd_test_kit/server/server_abstract_invoke_hook_test.rb
@@ -1,7 +1,6 @@
 require_relative 'server_hook_helper'
 require_relative '../cross_suite/tags'
 require_relative 'jobs/invoke_hook'
-require_relative 'endpoints/mock_ehr/fhir_request_handler'
 
 module DaVinciCRDTestKit
   class ServerAbstractInvokeHookTest < Inferno::Test
@@ -130,12 +129,10 @@ module DaVinciCRDTestKit
       failure_url = "#{resume_fail_url}?token=#{test_session_id}"
 
       acknowledge_before_continuing = manual_continuation == 'yes'
-      payloads.each do |parsed_request|
-        update_hook_request(parsed_request)
-      end
       Inferno::Jobs.perform(DaVinciCRDTestKit::Jobs::InvokeHook, test_session_id,
                             payloads, service_endpoint, inferno_base_url, jwks_kid, encryption_method,
-                            tested_hook_name, continuation_url, failure_url, acknowledge_before_continuing)
+                            tested_hook_name, continuation_url, failure_url, acknowledge_before_continuing,
+                            coverage_info_configuration_supported?)
 
       wait(
         identifier: test_session_id,
@@ -160,21 +157,8 @@ module DaVinciCRDTestKit
         'to continue the tests.'
     end
 
-    # point FHIR server and token details towards the CRD Server
-    # Test Suite's simulated FHIR server
-    def update_hook_request(parsed_request)
-      parsed_request['hookInstance'] = SecureRandom.uuid
-      parsed_request['fhirServer'] = fhir_url
-      update_simulated_server_token(parsed_request)
-    end
-
-    def update_simulated_server_token(parsed_request)
-      parsed_request['fhirAuthorization'] = {} if parsed_request['fhirAuthorization'].nil?
-      fhir_authorization = parsed_request['fhirAuthorization']
-
-      fhir_authorization['expires_in'] = 300 unless fhir_authorization['expires_in'].present?
-      fhir_authorization['access_token'] =
-        MockEHR::FHIRRequestHandler.session_id_to_token(test_session_id, fhir_authorization['expires_in'].to_i / 60)
+    def coverage_info_configuration_supported?
+      false
     end
   end
 end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/interaction/server_invoke_hook_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/interaction/server_invoke_hook_test.rb
@@ -6,6 +6,10 @@ module DaVinciCRDTestKit
     class ServerInvokeHookTest < ServerAbstractInvokeHookTest
       include ServerURLs
       id :crd_v220_server_invoke_hook_test
+
+      def coverage_info_configuration_supported?
+        true
+      end
     end
   end
 end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/server_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/server_appointment_book_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_response/card_optional_fields_validation_test'
 require_relative 'verify_response/external_reference_card_validation_test'
 require_relative 'verify_response/coverage_information_system_action_received_test'
 require_relative 'verify_response/coverage_information_system_action_validation_test'
+require_relative 'verify_response/coverage_info_configuration_test'
 require_relative 'verify_response/instructions_card_received_test'
 require_relative 'verify_response/form_completion_response_validation_test'
 require_relative 'verify_response/launch_smart_app_card_validation_test'
@@ -185,6 +186,7 @@ module DaVinciCRDTestKit
                  }
                }
              }
+        test from: :crd_v220_coverage_info_configuration
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/server_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/server_encounter_discharge_group.rb
@@ -10,6 +10,7 @@ require_relative 'verify_response/launch_smart_app_card_validation_test'
 require_relative 'verify_response/instructions_card_received_test'
 require_relative 'verify_response/form_completion_response_validation_test'
 require_relative 'verify_response/create_or_update_coverage_info_response_validation_test'
+require_relative 'verify_response/coverage_info_configuration_test'
 
 module DaVinciCRDTestKit
   module V220
@@ -180,6 +181,7 @@ module DaVinciCRDTestKit
                  }
                }
              }
+        test from: :crd_v220_coverage_info_configuration
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/server_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/server_encounter_start_group.rb
@@ -10,6 +10,7 @@ require_relative 'verify_response/launch_smart_app_card_validation_test'
 require_relative 'verify_response/instructions_card_received_test'
 require_relative 'verify_response/form_completion_response_validation_test'
 require_relative 'verify_response/create_or_update_coverage_info_response_validation_test'
+require_relative 'verify_response/coverage_info_configuration_test'
 
 module DaVinciCRDTestKit
   module V220
@@ -180,6 +181,7 @@ module DaVinciCRDTestKit
                  }
                }
              }
+        test from: :crd_v220_coverage_info_configuration
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/server_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/server_order_dispatch_group.rb
@@ -10,6 +10,7 @@ require_relative 'verify_response/launch_smart_app_card_validation_test'
 require_relative 'verify_response/instructions_card_received_test'
 require_relative 'verify_response/coverage_information_system_action_received_test'
 require_relative 'verify_response/coverage_information_system_action_validation_test'
+require_relative 'verify_response/coverage_info_configuration_test'
 require_relative 'verify_response/form_completion_response_validation_test'
 require_relative 'verify_response/create_or_update_coverage_info_response_validation_test'
 
@@ -185,6 +186,7 @@ module DaVinciCRDTestKit
                  }
                }
              }
+        test from: :crd_v220_coverage_info_configuration
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/server_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/server_order_select_group.rb
@@ -12,6 +12,7 @@ require_relative 'verify_response/propose_alternate_request_card_validation_test
 require_relative 'verify_response/additional_orders_validation_test'
 require_relative 'verify_response/form_completion_response_validation_test'
 require_relative 'verify_response/create_or_update_coverage_info_response_validation_test'
+require_relative 'verify_response/coverage_info_configuration_test'
 
 module DaVinciCRDTestKit
   module V220
@@ -205,6 +206,7 @@ module DaVinciCRDTestKit
                  }
                }
              }
+        test from: :crd_v220_coverage_info_configuration
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/server_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/server_order_sign_group.rb
@@ -10,6 +10,7 @@ require_relative 'verify_response/launch_smart_app_card_validation_test'
 require_relative 'verify_response/instructions_card_received_test'
 require_relative 'verify_response/coverage_information_system_action_received_test'
 require_relative 'verify_response/coverage_information_system_action_validation_test'
+require_relative 'verify_response/coverage_info_configuration_test'
 require_relative 'verify_response/propose_alternate_request_card_validation_test'
 require_relative 'verify_response/additional_orders_validation_test'
 require_relative 'verify_response/form_completion_response_validation_test'
@@ -210,6 +211,7 @@ module DaVinciCRDTestKit
                  }
                }
              }
+        test from: :crd_v220_coverage_info_configuration
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/verify_response/coverage_info_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/verify_response/coverage_info_configuration_test.rb
@@ -1,5 +1,4 @@
 require_relative '../../../cross_suite/cards_identification'
-require_relative '../../jwt_helper'
 require_relative '../../server_hook_helper'
 require_relative '../server_urls'
 
@@ -13,102 +12,79 @@ module DaVinciCRDTestKit
       title 'Coverage information configuration option suppresses coverage-info responses'
       id :crd_v220_coverage_info_configuration
       description %(
-        This test repeats prior successful hook requests that returned coverage-info content, with
-        `extension.davinci-crd.configuration.coverage-info` set to `false`.
+        This test checks follow-up hook requests made with
+        `extension.davinci-crd.configuration.coverage-info` set to `false` after prior successful hook requests
+        returned coverage-info content.
 
         CRD Servers SHALL behave in the manner prescribed by supported configuration information received from
         the CRD Client. When `coverage-info` is `false`, responses must not include coverage-info cards or
         coverage-information/form-completion system actions.
       )
 
-      input :encryption_method
-      input :jwks_kid, optional: true
-
-      def response_body(request)
-        JSON.parse(request.response_body)
-      rescue JSON::ParserError
-        nil
-      end
-
-      def response_has_coverage_info?(request)
-        body = response_body(request)
-        return false unless body.is_a?(Hash)
-
-        cards = body['cards']
-        system_actions = body['systemActions']
-        (cards.is_a?(Array) && cards.any? { |card| coverage_info_card_type?(card) }) ||
-          (system_actions.is_a?(Array) && system_actions.any? { |action| coverage_info_system_action_type?(action) })
-      end
-
-      def repeat_request_body(request)
-        body = JSON.parse(request.request_body)
-        body['hookInstance'] = SecureRandom.uuid
-        body['extension'] = {} unless body['extension'].is_a?(Hash)
-        unless body['extension']['davinci-crd.configuration'].is_a?(Hash)
-          body['extension']['davinci-crd.configuration'] = {}
-        end
-        body['extension']['davinci-crd.configuration'][COVERAGE_INFO_CONFIGURATION_CODE] = false
-        body
-      end
-
-      def invocation_headers(service_endpoint)
-        token = JwtHelper.build(
-          aud: service_endpoint,
-          iss: inferno_base_url,
-          jku: "#{inferno_base_url}/jwks.json",
-          kid: jwks_kid,
-          encryption_method:
-        )
-        { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
-      end
-
-      def repeat_hook_request(request)
-        Faraday.post(request.url, repeat_request_body(request).to_json, invocation_headers(request.url))
-      end
-
-      def coverage_info_content(response)
-        body = JSON.parse(response.body)
-        cards = body['cards'].is_a?(Array) ? body['cards'].select { |card| coverage_info_card_type?(card) } : []
-        actions =
-          if body['systemActions'].is_a?(Array)
-            body['systemActions'].select { |action| coverage_info_system_action_type?(action) }
-          else
-            []
-          end
-
-        [cards, actions]
-      end
-
       def coverage_info_message(cards, actions, response_index)
         card_summaries = cards.map { |card| card['summary'] }.compact
         action_descriptions = actions.map { |action| action['description'] }.compact
 
-        "Repeated server response #{response_index + 1} included coverage-info content despite " \
+        "Coverage-info disabled server response #{response_index + 1} included coverage-info content despite " \
           "`#{COVERAGE_INFO_CONFIGURATION_CODE}` being set to `false`. " \
           "Cards: #{card_summaries.join(', ')}. System actions: #{action_descriptions.join(', ')}."
+      end
+
+      def parsed_body(json)
+        JSON.parse(json)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def coverage_info_disabled_request?(request)
+        coverage_info_configuration_disabled?(parsed_body(request.request_body))
       end
 
       run do
         load_tagged_requests(tested_hook_name)
         skip_if requests.blank?, "No #{tested_hook_name} request was made in a previous test as expected."
 
-        repeatable_requests = requests
-          .select { |request| request.status == 200 && request.request_body.present? }
-          .select { |request| response_has_coverage_info?(request) }
+        successful_requests = requests.select { |request| request.status == 200 && request.request_body.present? }
+        requests_with_coverage_info = successful_requests
+          .reject { |request| coverage_info_disabled_request?(request) }
+          .select { |request| coverage_info_response?(parsed_body(request.response_body)) }
 
-        skip_if repeatable_requests.empty?,
+        skip_if requests_with_coverage_info.empty?,
                 "No successful #{tested_hook_name} response contained coverage-info content to suppress."
 
-        repeatable_requests.each_with_index do |request, index|
-          response = repeat_hook_request(request)
-          assert response.status == 200,
-                 "Repeated server request #{index + 1} returned HTTP #{response.status}; expected HTTP 200."
+        coverage_info_disabled_requests = requests
+          .select { |request| request.request_body.present? }
+          .select { |request| coverage_info_disabled_request?(request) }
 
-          cards, actions = coverage_info_content(response)
-          assert cards.empty? && actions.empty?, coverage_info_message(cards, actions, index)
-        rescue JSON::ParserError
-          assert false, "Repeated server response #{index + 1} was not valid JSON."
+        if coverage_info_disabled_requests.empty?
+          add_message(
+            'error',
+            "No #{tested_hook_name} request was made with `#{COVERAGE_INFO_CONFIGURATION_CODE}` set to `false`."
+          )
         end
+
+        coverage_info_disabled_requests.each_with_index do |request, index|
+          unless request.status == 200
+            add_message(
+              'error',
+              "Coverage-info disabled server request #{index + 1} returned HTTP #{request.status}; expected HTTP 200."
+            )
+            next
+          end
+
+          response_body = parsed_body(request.response_body)
+          unless response_body.is_a?(Hash)
+            add_message('error', "Coverage-info disabled server response #{index + 1} was not valid JSON.")
+            next
+          end
+
+          cards, actions = coverage_info_content(response_body)
+          next if cards.empty? && actions.empty?
+
+          add_message('error', coverage_info_message(cards, actions, index))
+        end
+
+        assert_no_error_messages('Coverage-info configuration responses were not valid. Check messages for details.')
       end
     end
   end

--- a/lib/davinci_crd_test_kit/server/v2.2.0/verify_response/coverage_info_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.0/verify_response/coverage_info_configuration_test.rb
@@ -1,0 +1,115 @@
+require_relative '../../../cross_suite/cards_identification'
+require_relative '../../jwt_helper'
+require_relative '../../server_hook_helper'
+require_relative '../server_urls'
+
+module DaVinciCRDTestKit
+  module V220
+    class CoverageInfoConfigurationTest < Inferno::Test
+      include DaVinciCRDTestKit::CardsIdentification
+      include DaVinciCRDTestKit::ServerHookHelper
+      include DaVinciCRDTestKit::V220::ServerURLs
+
+      title 'Coverage information configuration option suppresses coverage-info responses'
+      id :crd_v220_coverage_info_configuration
+      description %(
+        This test repeats prior successful hook requests that returned coverage-info content, with
+        `extension.davinci-crd.configuration.coverage-info` set to `false`.
+
+        CRD Servers SHALL behave in the manner prescribed by supported configuration information received from
+        the CRD Client. When `coverage-info` is `false`, responses must not include coverage-info cards or
+        coverage-information/form-completion system actions.
+      )
+
+      input :encryption_method
+      input :jwks_kid, optional: true
+
+      def response_body(request)
+        JSON.parse(request.response_body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def response_has_coverage_info?(request)
+        body = response_body(request)
+        return false unless body.is_a?(Hash)
+
+        cards = body['cards']
+        system_actions = body['systemActions']
+        (cards.is_a?(Array) && cards.any? { |card| coverage_info_card_type?(card) }) ||
+          (system_actions.is_a?(Array) && system_actions.any? { |action| coverage_info_system_action_type?(action) })
+      end
+
+      def repeat_request_body(request)
+        body = JSON.parse(request.request_body)
+        body['hookInstance'] = SecureRandom.uuid
+        body['extension'] = {} unless body['extension'].is_a?(Hash)
+        unless body['extension']['davinci-crd.configuration'].is_a?(Hash)
+          body['extension']['davinci-crd.configuration'] = {}
+        end
+        body['extension']['davinci-crd.configuration'][COVERAGE_INFO_CONFIGURATION_CODE] = false
+        body
+      end
+
+      def invocation_headers(service_endpoint)
+        token = JwtHelper.build(
+          aud: service_endpoint,
+          iss: inferno_base_url,
+          jku: "#{inferno_base_url}/jwks.json",
+          kid: jwks_kid,
+          encryption_method:
+        )
+        { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
+      end
+
+      def repeat_hook_request(request)
+        Faraday.post(request.url, repeat_request_body(request).to_json, invocation_headers(request.url))
+      end
+
+      def coverage_info_content(response)
+        body = JSON.parse(response.body)
+        cards = body['cards'].is_a?(Array) ? body['cards'].select { |card| coverage_info_card_type?(card) } : []
+        actions =
+          if body['systemActions'].is_a?(Array)
+            body['systemActions'].select { |action| coverage_info_system_action_type?(action) }
+          else
+            []
+          end
+
+        [cards, actions]
+      end
+
+      def coverage_info_message(cards, actions, response_index)
+        card_summaries = cards.map { |card| card['summary'] }.compact
+        action_descriptions = actions.map { |action| action['description'] }.compact
+
+        "Repeated server response #{response_index + 1} included coverage-info content despite " \
+          "`#{COVERAGE_INFO_CONFIGURATION_CODE}` being set to `false`. " \
+          "Cards: #{card_summaries.join(', ')}. System actions: #{action_descriptions.join(', ')}."
+      end
+
+      run do
+        load_tagged_requests(tested_hook_name)
+        skip_if requests.blank?, "No #{tested_hook_name} request was made in a previous test as expected."
+
+        repeatable_requests = requests
+          .select { |request| request.status == 200 && request.request_body.present? }
+          .select { |request| response_has_coverage_info?(request) }
+
+        skip_if repeatable_requests.empty?,
+                "No successful #{tested_hook_name} response contained coverage-info content to suppress."
+
+        repeatable_requests.each_with_index do |request, index|
+          response = repeat_hook_request(request)
+          assert response.status == 200,
+                 "Repeated server request #{index + 1} returned HTTP #{response.status}; expected HTTP 200."
+
+          cards, actions = coverage_info_content(response)
+          assert cards.empty? && actions.empty?, coverage_info_message(cards, actions, index)
+        rescue JSON::ParserError
+          assert false, "Repeated server response #{index + 1} was not valid JSON."
+        end
+      end
+    end
+  end
+end

--- a/spec/davinci_crd_test_kit/cards_identification_spec.rb
+++ b/spec/davinci_crd_test_kit/cards_identification_spec.rb
@@ -357,6 +357,20 @@ RSpec.describe DaVinciCRDTestKit::CardsIdentification do
     end
   end
 
+  describe 'when identifying coverage-info configuration response content' do
+    it 'identifies coverage-info cards by source type or source topic code' do
+      expect(module_instance.coverage_info_card_type?({ 'source' => { 'type' => 'coverage-info' } })).to be(true)
+      expect(module_instance.coverage_info_card_type?(instructions_card_template)).to be(true)
+      expect(module_instance.coverage_info_card_type?(external_reference_template)).to be(false)
+    end
+
+    it 'identifies coverage information and form completion system actions' do
+      expect(module_instance.coverage_info_system_action_type?(coverage_information_action_template)).to be(true)
+      expect(module_instance.coverage_info_system_action_type?(form_completion_action_template)).to be(true)
+      expect(module_instance.coverage_info_system_action_type?(create_coverage_action_template)).to be(false)
+    end
+  end
+
   describe 'when sorting cards by type' do
     it 'identifies cards and actions of each type' do
       all_types_request = create_inferno_request({ hookInstance: 'dummy' }.to_json, all_types_response.to_json)

--- a/spec/davinci_crd_test_kit/cards_identification_spec.rb
+++ b/spec/davinci_crd_test_kit/cards_identification_spec.rb
@@ -369,6 +369,25 @@ RSpec.describe DaVinciCRDTestKit::CardsIdentification do
       expect(module_instance.coverage_info_system_action_type?(form_completion_action_template)).to be(true)
       expect(module_instance.coverage_info_system_action_type?(create_coverage_action_template)).to be(false)
     end
+
+    it 'extracts coverage-info cards and actions from response bodies' do
+      cards, actions = module_instance.coverage_info_content(
+        'cards' => [instructions_card_template, external_reference_template],
+        'systemActions' => [coverage_information_action_template, create_coverage_action_template]
+      )
+
+      expect(cards).to eq([instructions_card_template])
+      expect(actions).to eq([coverage_information_action_template])
+      expect(module_instance.coverage_info_response?('cards' => cards, 'systemActions' => actions)).to be(true)
+    end
+
+    it 'sets and detects the coverage-info disabled configuration option' do
+      request_body = {}
+
+      module_instance.disable_coverage_info_configuration!(request_body)
+
+      expect(module_instance.coverage_info_configuration_disabled?(request_body)).to be(true)
+    end
   end
 
   describe 'when sorting cards by type' do

--- a/spec/davinci_crd_test_kit/hook_request_endpoint_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_endpoint_spec.rb
@@ -131,6 +131,60 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
     end
   end
 
+  describe '#apply_hook_configuration' do
+    let(:endpoint) { described_class.allocate }
+    let(:coverage_info_card) { { 'summary' => 'Coverage', 'source' => { 'type' => 'coverage-info' } } }
+    let(:coverage_info_topic_card) do
+      { 'summary' => 'Coverage topic', 'source' => { 'topic' => { 'code' => 'coverage-info' } } }
+    end
+    let(:guideline_card) { { 'summary' => 'Guideline', 'source' => { 'topic' => { 'code' => 'guideline' } } } }
+    let(:coverage_info_action) do
+      {
+        'type' => 'update',
+        'resource' => {
+          'resourceType' => 'ServiceRequest',
+          'extension' => [{ 'url' => DaVinciCRDTestKit::CardsIdentification::COVERAGE_INFO_EXT_URL }]
+        }
+      }
+    end
+    let(:form_completion_action) do
+      {
+        'type' => 'create',
+        'resource' => {
+          'resourceType' => 'Task',
+          'code' => { 'coding' => [{ 'code' => 'complete-questionnaire' }] },
+          'input' => [
+            {
+              'type' => { 'text' => 'questionnaire' },
+              'valueCanonical' => 'http://example.com/Questionnaire/example'
+            }
+          ]
+        }
+      }
+    end
+    let(:other_action) { { 'type' => 'delete', 'resource' => { 'resourceType' => 'ServiceRequest' } } }
+
+    it 'filters coverage-info cards and actions when the coverage-info configuration option is false' do
+      allow(endpoint).to receive(:request_body).and_return(
+        'extension' => {
+          'davinci-crd.configuration' => {
+            'coverage-info' => false
+          }
+        }
+      )
+
+      response_body = {
+        'cards' => [coverage_info_card, coverage_info_topic_card, guideline_card],
+        'systemActions' => [coverage_info_action, form_completion_action, other_action]
+      }
+
+      filtered_response = endpoint.apply_hook_configuration(response_body)
+
+      expect(filtered_response['cards']).to eq([guideline_card])
+      expect(filtered_response['systemActions']).to eq([other_action])
+    end
+  end
+
   describe 'When fetching data during a hook invocation' do
     it 'makes and tags requests for order-sign' do
       allow(test).to receive(:suite).and_return(suite)

--- a/spec/davinci_crd_test_kit/invoke_hook_spec.rb
+++ b/spec/davinci_crd_test_kit/invoke_hook_spec.rb
@@ -117,6 +117,29 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
       expect(coverage_info_disabled_request).to have_been_made.once
     end
 
+    it 'sends only one coverage-info disabled follow-up request per job' do
+      request_bodies = [service_request_body, service_request_body.deep_dup]
+      original_request = stub_request(:post, service_endpoint)
+        .with do |request|
+          JSON.parse(request.body).dig('extension', 'davinci-crd.configuration', 'coverage-info').nil?
+        end
+        .to_return(status: 200, body: coverage_info_response.to_json)
+      coverage_info_disabled_request = stub_request(:post, service_endpoint)
+        .with do |request|
+          JSON.parse(request.body).dig('extension', 'davinci-crd.configuration', 'coverage-info') == false
+        end
+        .to_return(status: 200, body: filtered_response.to_json)
+      stub_request(:get, continuation_url).to_return(status: 200)
+
+      described_class.new.perform(
+        test_session_id, request_bodies, service_endpoint, inferno_base_url,
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, true
+      )
+
+      expect(original_request).to have_been_made.twice
+      expect(coverage_info_disabled_request).to have_been_made.once
+    end
+
     it 'does not invoke the continuation url after successful hook invocations if acknowledgement required' do
       hook_request = stub_request(:post, service_endpoint).to_return(status: 200)
       continuation_request = stub_request(:get, continuation_url).to_return(status: 200)

--- a/spec/davinci_crd_test_kit/invoke_hook_spec.rb
+++ b/spec/davinci_crd_test_kit/invoke_hook_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
   let(:service_endpoint) { "#{discovery_url}/#{service_ids}" }
   let(:encryption_method) { 'ES384' }
   let(:invoked_hook) { 'appointment-book' }
+  let(:coverage_info_response) do
+    {
+      cards: [
+        {
+          summary: 'Coverage information',
+          indicator: 'info',
+          source: { type: DaVinciCRDTestKit::CardsIdentification::COVERAGE_INFO_CONFIGURATION_CODE }
+        }
+      ]
+    }
+  end
+  let(:filtered_response) { { cards: [] } }
   let(:continuation_url) do
     "#{inferno_base_url}/custom/#{suite_id}/resume_pass?token=#{test_session_id}"
   end
@@ -53,11 +65,56 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
 
       described_class.new.perform(
         test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
-        nil, encryption_method, invoked_hook, continuation_url, failure_url, false
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, false
       )
 
       expect(hook_request).to have_been_made.once
       expect(continuation_request).to have_been_made.once
+    end
+
+    it 'updates hook request details before invoking the service' do
+      original_hook_instance = service_request_body['hookInstance']
+      hook_request = stub_request(:post, service_endpoint)
+        .with do |request|
+          request_body = JSON.parse(request.body)
+          token = request_body.dig('fhirAuthorization', 'access_token')
+          token_body = JSON.parse(Base64.urlsafe_decode64(token))
+
+          request_body['hookInstance'] != original_hook_instance &&
+            request_body['fhirServer'] == "#{inferno_base_url}/fhir" &&
+            token_body['session_id'] == test_session_id
+        end
+        .to_return(status: 200)
+      stub_request(:get, continuation_url).to_return(status: 200)
+
+      described_class.new.perform(
+        test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, false
+      )
+
+      expect(hook_request).to have_been_made.once
+    end
+
+    it 'sends one follow-up request with coverage-info disabled when coverage-info content is returned' do
+      original_request = stub_request(:post, service_endpoint)
+        .with do |request|
+          JSON.parse(request.body).dig('extension', 'davinci-crd.configuration', 'coverage-info').nil?
+        end
+        .to_return(status: 200, body: coverage_info_response.to_json)
+      coverage_info_disabled_request = stub_request(:post, service_endpoint)
+        .with do |request|
+          JSON.parse(request.body).dig('extension', 'davinci-crd.configuration', 'coverage-info') == false
+        end
+        .to_return(status: 200, body: filtered_response.to_json)
+      stub_request(:get, continuation_url).to_return(status: 200)
+
+      described_class.new.perform(
+        test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, true
+      )
+
+      expect(original_request).to have_been_made.once
+      expect(coverage_info_disabled_request).to have_been_made.once
     end
 
     it 'does not invoke the continuation url after successful hook invocations if acknowledgement required' do
@@ -69,7 +126,7 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
 
       described_class.new.perform(
         test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
-        nil, encryption_method, invoked_hook, continuation_url, failure_url, true
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, true, false
       )
 
       expect(hook_request).to have_been_made.once
@@ -85,7 +142,7 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
 
       described_class.new.perform(
         test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
-        nil, encryption_method, invoked_hook, continuation_url, failure_url, false
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, false
       )
       expect(failure_request).to have_been_made.once
     end
@@ -110,7 +167,7 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
 
       described_class.new.perform(
         test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
-        nil, encryption_method, invoked_hook, continuation_url, failure_url, false
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, false
       )
 
       expect(hook_request).to have_been_made.once
@@ -130,7 +187,7 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
 
       described_class.new.perform(
         test_session_id, service_request_bodies, service_endpoint, inferno_base_url,
-        nil, encryption_method, invoked_hook, continuation_url, failure_url, false
+        nil, encryption_method, invoked_hook, continuation_url, failure_url, false, false
       )
 
       expect(hook_request).to_not have_been_made

--- a/spec/davinci_crd_test_kit/routes/cds_services_discovery_handler_spec.rb
+++ b/spec/davinci_crd_test_kit/routes/cds_services_discovery_handler_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe DaVinciCRDTestKit::CDSServicesDiscoveryHandler, :request do
 
       services.all? do |service|
         expect(service).to include('hook', 'description', 'id')
+        expect(service.dig('extension', 'davinci-crd.configuration-options')).to include(
+          a_hash_including(
+            'code' => 'coverage-info',
+            'type' => 'boolean',
+            'name' => 'Coverage Information',
+            'default' => true
+          )
+        )
       end
     end
   end

--- a/spec/davinci_crd_test_kit/server_invoke_hook_test_spec.rb
+++ b/spec/davinci_crd_test_kit/server_invoke_hook_test_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe DaVinciCRDTestKit::V201::ServerInvokeHookTest do
       expect_any_instance_of(DaVinciCRDTestKit::Jobs::InvokeHook) # rubocop:disable RSpec/StubbedMock
         .to receive(:perform)
         .with(anything, anything, "#{discovery_url}/#{service_ids}", anything, anything, anything,
-              DaVinciCRDTestKit::ANY_HOOK_TAG, anything, anything, anything)
+              DaVinciCRDTestKit::ANY_HOOK_TAG, anything, anything, anything, false)
         .and_return(nil)
 
       result = run(runnable, base_url:, inferno_base_url:, service_ids: '', encryption_method:,

--- a/spec/davinci_crd_test_kit/v2.2.0/coverage_info_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.0/coverage_info_configuration_test_spec.rb
@@ -68,45 +68,67 @@ RSpec.describe DaVinciCRDTestKit::V220::CoverageInfoConfigurationTest do
     )
   end
 
-  def mock_previous_request(request)
-    allow_any_instance_of(runnable).to receive(:tested_hook_name).and_return('order-sign')
-    allow_any_instance_of(runnable).to receive(:requests).and_return([request])
+  def coverage_info_disabled_request_body
+    hook_request.deep_dup.tap do |request_body|
+      request_body['hookInstance'] = SecureRandom.uuid
+      request_body['extension'] = {
+        'davinci-crd.configuration' => {
+          'coverage-info' => false
+        }
+      }
+    end
   end
 
-  it 'repeats prior coverage-info responses with coverage-info disabled' do
-    request = create_service_request
-    mock_previous_request(request)
-    repeated_request = stub_request(:post, service_endpoint)
-      .with do |webmock_request|
-        repeated_body = JSON.parse(webmock_request.body)
-        repeated_body.dig('extension', 'davinci-crd.configuration', 'coverage-info') == false &&
-          repeated_body['hookInstance'] != hook_request['hookInstance']
-      end
-      .to_return(status: 200, body: filtered_response.to_json)
+  def entity_result_messages
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+  end
 
-    result = run(runnable, encryption_method: 'RS384')
+  def mock_previous_requests(*requests)
+    allow_any_instance_of(runnable).to receive(:tested_hook_name).and_return('order-sign')
+    allow_any_instance_of(runnable).to receive(:requests).and_return(requests)
+  end
+
+  it 'passes when coverage-info disabled responses omit coverage-info content' do
+    original_request = create_service_request
+    disabled_request =
+      create_service_request(body: filtered_response, request_body: coverage_info_disabled_request_body)
+    mock_previous_requests(original_request, disabled_request)
+
+    result = run(runnable)
 
     expect(result.result).to eq('pass')
-    expect(repeated_request).to have_been_made.once
   end
 
-  it 'fails if the repeated response still contains coverage-info content' do
-    request = create_service_request
-    mock_previous_request(request)
-    stub_request(:post, service_endpoint)
-      .to_return(status: 200, body: original_response.to_json)
+  it 'fails if the coverage-info disabled response still contains coverage-info content' do
+    original_request = create_service_request
+    disabled_request = create_service_request(request_body: coverage_info_disabled_request_body)
+    mock_previous_requests(original_request, disabled_request)
 
-    result = run(runnable, encryption_method: 'RS384')
+    result = run(runnable)
 
     expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/included coverage-info content/)
+    expect(result.result_message).to match(/Coverage-info configuration responses were not valid/)
+    expect(entity_result_messages.map(&:message).join(' ')).to match(/included coverage-info content/)
+  end
+
+  it 'fails if no coverage-info disabled follow-up request was made after coverage-info content was returned' do
+    request = create_service_request
+    mock_previous_requests(request)
+
+    result = run(runnable)
+
+    expect(result.result).to eq('fail')
+    expect(entity_result_messages.map(&:message).join(' '))
+      .to match(/No order-sign request was made with `coverage-info` set to `false`/)
   end
 
   it 'skips when prior responses did not include coverage-info content' do
     request = create_service_request(body: filtered_response)
-    mock_previous_request(request)
+    mock_previous_requests(request)
 
-    result = run(runnable, encryption_method: 'RS384')
+    result = run(runnable)
 
     expect(result.result).to eq('skip')
     expect(result.result_message).to match(/No successful order-sign response contained coverage-info/)

--- a/spec/davinci_crd_test_kit/v2.2.0/coverage_info_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.0/coverage_info_configuration_test_spec.rb
@@ -1,0 +1,114 @@
+require_relative '../../../lib/davinci_crd_test_kit/server/v2.2.0/verify_response/coverage_info_configuration_test'
+
+RSpec.describe DaVinciCRDTestKit::V220::CoverageInfoConfigurationTest do
+  let(:suite_id) { 'crd_client' }
+  let(:runnable) { described_class }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+
+  let(:service_endpoint) { 'http://example.com/cds-services/order-sign-service' }
+  let(:hook_request) do
+    JSON.parse(File.read(File.join(
+                           __dir__, '..', '..', 'fixtures', 'order_sign_hook_request.json'
+                         )))
+  end
+  let(:coverage_info_card) do
+    {
+      'summary' => 'Coverage information',
+      'indicator' => 'info',
+      'source' => { 'type' => 'coverage-info' }
+    }
+  end
+  let(:guideline_card) do
+    {
+      'summary' => 'Guideline',
+      'indicator' => 'info',
+      'source' => { 'topic' => { 'code' => 'guideline' } }
+    }
+  end
+  let(:coverage_info_action) do
+    {
+      'type' => 'update',
+      'description' => 'Added coverage information',
+      'resource' => {
+        'resourceType' => 'ServiceRequest',
+        'id' => 'service-request-1',
+        'status' => 'draft',
+        'intent' => 'order',
+        'extension' => [
+          {
+            'url' => DaVinciCRDTestKit::CardsIdentification::COVERAGE_INFO_EXT_URL
+          }
+        ]
+      }
+    }
+  end
+  let(:original_response) do
+    {
+      'cards' => [coverage_info_card, guideline_card],
+      'systemActions' => [coverage_info_action]
+    }
+  end
+  let(:filtered_response) do
+    {
+      'cards' => [guideline_card],
+      'systemActions' => []
+    }
+  end
+
+  def create_service_request(body: original_response, status: 200, request_body: hook_request)
+    repo_create(
+      :request,
+      direction: 'outgoing',
+      url: service_endpoint,
+      test_session_id: test_session.id,
+      request_body: request_body.to_json,
+      response_body: body.to_json,
+      status:,
+      headers: nil
+    )
+  end
+
+  def mock_previous_request(request)
+    allow_any_instance_of(runnable).to receive(:tested_hook_name).and_return('order-sign')
+    allow_any_instance_of(runnable).to receive(:requests).and_return([request])
+  end
+
+  it 'repeats prior coverage-info responses with coverage-info disabled' do
+    request = create_service_request
+    mock_previous_request(request)
+    repeated_request = stub_request(:post, service_endpoint)
+      .with do |webmock_request|
+        repeated_body = JSON.parse(webmock_request.body)
+        repeated_body.dig('extension', 'davinci-crd.configuration', 'coverage-info') == false &&
+          repeated_body['hookInstance'] != hook_request['hookInstance']
+      end
+      .to_return(status: 200, body: filtered_response.to_json)
+
+    result = run(runnable, encryption_method: 'RS384')
+
+    expect(result.result).to eq('pass')
+    expect(repeated_request).to have_been_made.once
+  end
+
+  it 'fails if the repeated response still contains coverage-info content' do
+    request = create_service_request
+    mock_previous_request(request)
+    stub_request(:post, service_endpoint)
+      .to_return(status: 200, body: original_response.to_json)
+
+    result = run(runnable, encryption_method: 'RS384')
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to match(/included coverage-info content/)
+  end
+
+  it 'skips when prior responses did not include coverage-info content' do
+    request = create_service_request(body: filtered_response)
+    mock_previous_request(request)
+
+    result = run(runnable, encryption_method: 'RS384')
+
+    expect(result.result).to eq('skip')
+    expect(result.result_message).to match(/No successful order-sign response contained coverage-info/)
+  end
+end


### PR DESCRIPTION
## Summary

This PR implements CRD 2.2 server simulation support for the `coverage-info` configuration option.

**Changes include:**

- Adds the `coverage-info` option to every published v2.2.0 CDS service in `cds-services-v220.json` using the CRD IG configuration options extension.
- Filters simulated CRD Client Suite hook responses when a request includes:

```json
{
  "extension": {
    "davinci-crd.configuration": {
      "coverage-info": false
    }
  }
}
```
- When `coverage-info` is `false`, removes:
  - cards with `source.type = "coverage-info"`
  - cards with `source.topic.code = "coverage-info"`
  - systemActions identified as `coverage_information`
  - systemActions identified as `form_completion`
- Adds a CRD Server v2.2.0 validation test, `crd_v220_coverage_info_configuration`, which repeats prior successful hook requests that returned coverage-info content and verifies the repeated response no longer includes coverage-info content.
- Adds focused tests for discovery output, endpoint filtering, response type identification, and the new server validation test.

## UI Testing Steps

1. Run CRD Server v2.2.0 Test Suite => Running the CRD Client and Server Suites Against Each Other => [https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Running-Suites-Against-Each-Other](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Running-Suites-Against-Each-Other)

2. Inspect each service in the JSON response. The following service IDs should include the `coverage-info` configuration option:

- `appointment-book`
- `encounter-start`
- `encounter-discharge`
- `order-select`
- `order-dispatch`
- `order-sign`

3. In each service, confirm this area is present:

```json
{
  "extension": {
    "davinci-crd.configuration-options": {
      "coverage-info": {
        "type": "boolean",
        "name": "Coverage Information",
        "default": true
      }
    }
  }
}
```

4. Confirm Validation Test Appears in UI

- Navigate to: => Hook Tests => any hook => Verify Responses
- Confirm presence of test: Coverage information configuration option suppresses coverage-info responses

5. Validate Filtering Behavior

- Run a hook (e.g., order-sign)
- Go to: Verify Responses => All service responses contain valid cards
- Confirm original response contains:
  - coverage-info cards
  - coverage-information systemActions
  - form-completion systemActions

- Open: Coverage information configuration option suppresses coverage-info responses

- Inspect rerun request/response

**Confirm:**

- No cards with: source.topic.code = coverage-info

**No systemActions:**

- coverage-information
- form-completion

**Expected behavior:**

- Test passes when filtered correctly
- Test skips if no coverage content existed
- Test fails if any coverage-info content remains