### PR TITLE
FQM-276: Check service versions

### DIFF
--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -66,23 +66,27 @@ module DaVinciCRDTestKit
 
         services.each do |service|
           required_fields.each do |field, type|
-            assert(service[field], "Service `#{service}` did not contain required field: `#{field}`")
-            assert(service[field].is_a?(type), "Service `#{service}`: field `#{field}` is not of type #{type}")
+            assert(service[field], "Service `#{service['id']}` did not contain required field: `#{field}`")
+            assert(service[field].is_a?(type), "Service `#{service['id']}`: field `#{field}` is not of type #{type}")
           end
 
           assert service['extension'].key?(EXTENSION_KEY),
-                 "Service `#{service}`: does not contain a `#{EXTENSION_KEY}` extension"
+                 "Service `#{service['id']}`: does not contain a `#{EXTENSION_KEY}` extension"
           assert service['extension'][EXTENSION_KEY].is_a?(Array),
-                 "Service `#{service}`: `#{EXTENSION_KEY}` extension is not of type Array"
+                 "Service `#{service['id']}`: `#{EXTENSION_KEY}` extension is not of type Array"
           assert service['extension'][EXTENSION_KEY].present?,
-                 "Service `#{service}`: `#{EXTENSION_KEY}` extension is empty"
+                 "Service `#{service['id']}`: `#{EXTENSION_KEY}` extension is empty"
+          non_string_values = service['extension'][EXTENSION_KEY].reject { |value| value.is_a? String }
+          assert non_string_values.blank?,
+                 "Service `#{service['id']}`: `#{EXTENSION_KEY}` extension contains non-string values: " \
+                 "#{non_string_values.join(', ')}"
 
           invalid_versions =
             service['extension'][EXTENSION_KEY] # rubocop:disable Style/SelectByRegexp
               .reject { |version| version.match?(/\A\d+\.\d+\Z/) }
 
           assert invalid_versions.blank?,
-                 "Service `#{service}`: `#{EXTENSION_KEY}` extension contains invalid " \
+                 "Service `#{service['id']}`: `#{EXTENSION_KEY}` extension contains invalid " \
                  "version strings: #{invalid_versions.join(', ')}"
         end
       end

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -83,7 +83,7 @@ module DaVinciCRDTestKit
 
           invalid_versions =
             service['extension'][EXTENSION_KEY] # rubocop:disable Style/SelectByRegexp
-              .reject { |version| version.match?(/\A\d+\.\d+\Z/) }
+              .reject { |version| version.match?(/\A[1-9]\d*.\d+\Z/) }
 
           assert invalid_versions.blank?,
                  "Service `#{service['id']}`: `#{EXTENSION_KEY}` extension contains invalid " \

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -83,7 +83,7 @@ module DaVinciCRDTestKit
 
           invalid_versions =
             service['extension'][EXTENSION_KEY] # rubocop:disable Style/SelectByRegexp
-              .reject { |version| version.match?(/\A[1-9]\d*.\d+\Z/) }
+              .reject { |version| version.match?(/\A[1-9]\d*\.\d+\Z/) }
 
           assert invalid_versions.blank?,
                  "Service `#{service['id']}`: `#{EXTENSION_KEY}` extension contains invalid " \

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -17,6 +17,12 @@ module DaVinciCRDTestKit
         Each CDS service must contain the following required fields:
         `hook`, `description`, and `id`.
 
+        Additionally, the [CRD
+        Spec](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/deviations.html#crd-version-declaration)
+        states that "CRD servers SHALL declare at least one supported CRD
+        version for each supported hook" using the `davinci-crd.version`
+        extension.
+
         This test checks for the presence of the required fields and
         validates that they are of the correct type.
 
@@ -27,11 +33,14 @@ module DaVinciCRDTestKit
       output :appointment_book_service_ids, :encounter_start_service_ids, :encounter_discharge_service_ids,
              :order_dispatch_service_ids, :order_select_service_ids, :order_sign_service_ids
 
+      EXTENSION_KEY = 'davinci-crd.version'.freeze
+
       def required_fields
         {
           'hook' => String,
           'description' => String,
-          'id' => String
+          'id' => String,
+          'extension' => Hash
         }
       end
 
@@ -60,6 +69,21 @@ module DaVinciCRDTestKit
             assert(service[field], "Service `#{service}` did not contain required field: `#{field}`")
             assert(service[field].is_a?(type), "Service `#{service}`: field `#{field}` is not of type #{type}")
           end
+
+          assert service['extension'].key?(EXTENSION_KEY),
+                 "Service `#{service}`: does not contain a `#{EXTENSION_KEY}` extension"
+          assert service['extension'][EXTENSION_KEY].is_a?(Array),
+                 "Service `#{service}`: `#{EXTENSION_KEY}` extension is not of type Array"
+          assert service['extension'][EXTENSION_KEY].present?,
+                 "Service `#{service}`: `#{EXTENSION_KEY}` extension is empty"
+
+          invalid_versions =
+            service['extension'][EXTENSION_KEY] # rubocop:disable Style/SelectByRegexp
+              .reject { |version| version.match?(/\A\d+\.\d+\Z/) }
+
+          assert invalid_versions.blank?,
+                 "Service `#{service}`: `#{EXTENSION_KEY}` extension contains invalid " \
+                 "version strings: #{invalid_versions.join(', ')}"
         end
       end
     end

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
     expect(result.result_message).to match(/is empty/)
   end
 
+  it 'fails when the davinci-crd.version extension contains non-string values' do
+    service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
+    service2 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', 2.2] })
+
+    cds_services = { 'services' => [service1, service2] }.to_json
+
+    result = run(runnable, cds_services:)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(result.result_message).to match(/contains non-string values/)
+  end
+
   it 'fails when the davinci-crd.version extension contains in improperly formatted version' do
     service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
     service2 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.2.1'] })

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
+  let(:suite_id) { 'crd_client' }
+  let(:runnable) { described_class }
+  let(:cds_service) do
+    {
+      'hook' => 'appointment-book',
+      'title' => 'Appointment Booking CDS Service',
+      'description' => 'An example of a CDS Service that is invoked when user of a CRD Client books an appointment',
+      'id' => 'appointment-book-service',
+      'prefetch' => {
+        'user' => '{{context.userId}}',
+        'patient' => 'Patient/{{context.patientId}}'
+      }
+    }
+  end
+
+  it 'succeeds when all services contain a valid davinci-crd.version extension' do
+    service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
+    service2 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.2'] })
+
+    cds_services = { 'services' => [service1, service2] }.to_json
+
+    result = run(runnable, cds_services:)
+
+    expect(result.result).to eq('pass'), result.result_message
+  end
+
+  it 'fails when the davinci-crd.version extension is not present' do
+    service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
+    service2 = cds_service.merge('extension' => { 'davinci-crd.x' => ['2.2'] })
+
+    cds_services = { 'services' => [service1, service2] }.to_json
+
+    result = run(runnable, cds_services:)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(result.result_message).to match(/does not contain/)
+  end
+
+  it 'fails when the davinci-crd.version extension is not an Array' do
+    service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
+    service2 = cds_service.merge('extension' => { 'davinci-crd.version' => '2.2' })
+
+    cds_services = { 'services' => [service1, service2] }.to_json
+
+    result = run(runnable, cds_services:)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(result.result_message).to match(/is not of type Array/)
+  end
+
+  it 'fails when the davinci-crd.version extension is empty' do
+    service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
+    service2 = cds_service.merge('extension' => { 'davinci-crd.version' => [] })
+
+    cds_services = { 'services' => [service1, service2] }.to_json
+
+    result = run(runnable, cds_services:)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(result.result_message).to match(/is empty/)
+  end
+
+  it 'fails when the davinci-crd.version extension contains in improperly formatted version' do
+    service1 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.1', '2.2'] })
+    service2 = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.2.1'] })
+
+    cds_services = { 'services' => [service1, service2] }.to_json
+
+    result = run(runnable, cds_services:)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(result.result_message).to match(/invalid version strings/)
+  end
+end


### PR DESCRIPTION
# Summary
This branch adds a new check to the discovery tests to verify that each service advertises the CRD versions it supports.

# Testing Guidance
The discovery test passes using the preset. Errors cases are demonstrated in the unit tests.