### PR TITLE
FQM-278: Check if-none-exist extension

### DIFF
--- a/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
@@ -145,6 +145,10 @@ module DaVinciCRDTestKit
       ['create', 'update'].include?(action['type']) && action_resource_type_check(action, ['Coverage'])
     end
 
+    def create_questionnaire_action_response_type?(action)
+      action['type'] == 'create' && action_resource_type_check(action, ['Questionnaire'])
+    end
+
     def external_reference_response_type?(card)
       card['links']&.all? { |link| link['type'] == 'absolute' }
     end

--- a/lib/davinci_crd_test_kit/cross_suite/suggestion_actions_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/suggestion_actions_validation.rb
@@ -103,7 +103,7 @@ module DaVinciCRDTestKit
       add_message('error', error_msg)
     end
 
-    def questionnaire_creation_check(action)
+    def questionnaire_creation_check(action) # rubocop:disable Metrics/CyclomaticComplexity
       return unless action.dig('resource', 'resourceType') == 'Questionnaire'
 
       extension_value = action.dig('extension', 'davinci-crd.if-none-exist')

--- a/lib/davinci_crd_test_kit/cross_suite/suggestion_actions_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/suggestion_actions_validation.rb
@@ -103,21 +103,17 @@ module DaVinciCRDTestKit
       add_message('error', error_msg)
     end
 
-    def questionnaire_creation_check(action) # rubocop:disable Metrics/CyclomaticComplexity
+    def questionnaire_creation_check(action)
       return unless action.dig('resource', 'resourceType') == 'Questionnaire'
 
       extension_value = action.dig('extension', 'davinci-crd.if-none-exist')
 
-      return if extension_value.is_a?(Array) && extension_value.all? { |value| value.is_a? String }
-
       if extension_value.nil?
         add_message('error', '`davinci-crd.if-none-exist` extension is not present.')
-      elsif !extension_value.is_a? Array
-        add_message('error', '`davinci-crd.if-none-exist` extension is not an Array.')
+      elsif !extension_value.is_a? String
+        add_message('error', '`davinci-crd.if-none-exist` extension is not a string.')
       elsif extension_value.blank?
-        add_message('error', '`davinci-crd.if-none-exist` extension is empty.')
-      elsif extension_value.any? { |value| !value.is_a? String }
-        add_message('error', '`davinci-crd.if-none-exist` extension contains non-String values.')
+        add_message('error', '`davinci-crd.if-none-exist` extension is an empty string.')
       end
     end
 

--- a/lib/davinci_crd_test_kit/cross_suite/suggestion_actions_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/suggestion_actions_validation.rb
@@ -92,6 +92,7 @@ module DaVinciCRDTestKit
     def create_or_update_action_check(action, contexts, ig_version: 'v201')
       resource = FHIR.from_contents(action['resource'].to_json)
       resource_is_valid?(resource:, profile_url: structure_definition_map(ig_version)[resource.resourceType])
+
       return unless action['type'] == 'update' && contexts
 
       ref = "#{resource.resourceType}/#{resource.id}"
@@ -100,6 +101,24 @@ module DaVinciCRDTestKit
       error_msg = "Resource being updated must be from the `draftOrders` entry. #{ref} is not in the " \
                   "`context.draftOrders` of the submitted requests. In Action `#{action}`"
       add_message('error', error_msg)
+    end
+
+    def questionnaire_creation_check(action)
+      return unless action.dig('resource', 'resourceType') == 'Questionnaire'
+
+      extension_value = action.dig('extension', 'davinci-crd.if-none-exist')
+
+      return if extension_value.is_a?(Array) && extension_value.all? { |value| value.is_a? String }
+
+      if extension_value.nil?
+        add_message('error', '`davinci-crd.if-none-exist` extension is not present.')
+      elsif !extension_value.is_a? Array
+        add_message('error', '`davinci-crd.if-none-exist` extension is not an Array.')
+      elsif extension_value.blank?
+        add_message('error', '`davinci-crd.if-none-exist` extension is empty.')
+      elsif extension_value.any? { |value| !value.is_a? String }
+        add_message('error', '`davinci-crd.if-none-exist` extension contains non-String values.')
+      end
     end
 
     def delete_action_check(action, create_actions_resource_types, contexts)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/form_completion_response_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/form_completion_response_validation_test.rb
@@ -29,7 +29,11 @@ module DaVinciCRDTestKit
 
         - **Validating:**
           If any Request Form Completion cards or system actions are found, the test proceeds to validate them.
-          Each `Task` resource is validated against the [CRD Questionnaire Task profile](http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-taskquestionnaire).
+          Each `Task` resource is validated against the [CRD Questionnaire Task
+          profile](http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-taskquestionnaire).
+          Additionally, if any actions for the creation of a `Questionnaire` are
+          found, the test verifies that they include the
+          `davinci-crd.if-none-exist` extension.
 
         If no Request Form Completion cards or system actions are received, the test is skipped.
       )
@@ -59,6 +63,16 @@ module DaVinciCRDTestKit
             end
           end
         end
+
+        questionnaire_create_actions =
+          parsed_actions.select { |action| create_questionnaire_action_response_type?(action) } +
+          form_completion_cards
+            .flat_map { |card| card['suggestions'] }
+            .flat_map { |suggestion| suggestion['actions'] }
+            .compact
+            .select { |action| create_questionnaire_action_response_type?(action) }
+
+        questionnaire_create_actions.each { |action| questionnaire_creation_check(action) }
 
         no_error_validation('Some Request Form Completion received are not valid.')
       end

--- a/spec/davinci_crd_test_kit/cards_identification_spec.rb
+++ b/spec/davinci_crd_test_kit/cards_identification_spec.rb
@@ -341,6 +341,35 @@ RSpec.describe DaVinciCRDTestKit::CardsIdentification do
     end
   end
 
+  describe 'when identifying create questionnaire actions' do
+    it 'returns true for a matching action' do
+      action =
+        {
+          'type' => 'create',
+          'description' => 'Create form',
+          'resource' => {
+            'resourceType' => 'Questionnaire',
+            'url' => 'http://example.org/Questionnaire/XYZ'
+          }
+        }
+      expect(module_instance.create_questionnaire_action_response_type?(action)).to be(true)
+    end
+
+    it 'returns false for a non-matching cards' do
+      action =
+        {
+          'type' => 'update',
+          'description' => 'Update form',
+          'resource' => {
+            'resourceType' => 'Questionnaire',
+            'url' => 'http://example.org/Questionnaire/XYZ'
+          }
+        }
+
+      expect(module_instance.create_questionnaire_action_response_type?(action)).to be(false)
+    end
+  end
+
   describe 'when identifying form completion actions' do
     it 'correctly identifies the type' do
       expect(module_instance.identify_action_type(form_completion_action_template))

--- a/spec/davinci_crd_test_kit/v2.2.1/form_completion_response_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/form_completion_response_validation_test_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe DaVinciCRDTestKit::V221::FormCompletionResponseValidationTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:runnable) { described_class }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:base_card) do
+    {
+      'summary' => 'Order Select Request Form Completion Card',
+      'uuid' => 'jksfghisldlrldsse',
+      'detail' => 'This is a Card containing one or more suggestions.',
+      'indicator' => 'info',
+      'source' => {
+        'label' => 'Inferno',
+        'url' => 'https://inferno.healthit.gov/',
+        'topic' => {
+          'system' => 'http://hl7.org/fhir/us/davinci-crd/CodeSystem/temp',
+          'code' => 'order-select',
+          'display' => 'Order Select'
+        }
+      },
+      'selectionBehavior' => 'any',
+      'suggestions' => [
+        {
+          'label' => "Add 'completion of the ABC form' to your task list (possibly for reassignment)",
+          'actions' => [
+            {
+              'type' => 'create',
+              'description' => 'Create form',
+              'resource' => {
+                'resourceType' => 'Questionnaire',
+                'url' => 'http://example.org/Questionnaire/XYZ'
+              }
+            },
+            {
+              'type' => 'create',
+              'description' => 'Create task',
+              'resource' => {
+                'resourceType' => 'Task',
+                'code' => {
+                  'coding' => [
+                    {
+                      'system' => 'http://hl7.org/fhir/uv/sdc/CodeSystem/temp',
+                      'code' => 'complete-questionnaire'
+                    }
+                  ]
+                },
+                'input' => [
+                  {
+                    'type' => {
+                      'text' => 'questionnaire',
+                      'coding' => [
+                        {
+                          'system' => 'http://hl7.org/fhir/uv/sdc/CodeSystem/temp',
+                          'code' => 'questionnaire'
+                        }
+                      ]
+                    },
+                    'valueCanonical' => 'http://example.org/Questionnaire/XYZ'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+      .first
+  end
+
+  before do
+    allow_any_instance_of(runnable).to receive(:resource_is_valid?).and_return(true)
+  end
+
+  it 'passes if questionnaire creation actions include the if-none-exist extension' do
+    card = base_card
+    card['suggestions'].first['actions'].first['extension'] = {
+      'davinci-crd.if-none-exist': ['http://example.org/Questionnaire/XYZ']
+    }
+    result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
+                 valid_system_actions: [].to_json)
+
+    expect(result.result).to eq('pass'), result.result_message
+  end
+
+  it 'fails if form creation actions do not include the if-none-exist extension' do
+    result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
+                 valid_system_actions: [].to_json)
+
+    expect(result.result).to eq('fail')
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/form_completion_response_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/form_completion_response_validation_test_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe DaVinciCRDTestKit::V221::FormCompletionResponseValidationTest do
   it 'passes if questionnaire creation actions include the if-none-exist extension' do
     card = base_card
     card['suggestions'].first['actions'].first['extension'] = {
-      'davinci-crd.if-none-exist': ['http://example.org/Questionnaire/XYZ']
+      'davinci-crd.if-none-exist': 'http://example.org/Questionnaire/XYZ'
     }
     result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
                            valid_system_actions: [].to_json)
@@ -92,5 +92,30 @@ RSpec.describe DaVinciCRDTestKit::V221::FormCompletionResponseValidationTest do
                            valid_system_actions: [].to_json)
 
     expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/is not present/)
+  end
+
+  it 'fails if the if-none-exist extension is the wrong type' do
+    card = base_card
+    card['suggestions'].first['actions'].first['extension'] = {
+      'davinci-crd.if-none-exist': ['http://example.org/Questionnaire/XYZ']
+    }
+    result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
+                           valid_system_actions: [].to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(entity_result_message.message).to match(/is not a string/)
+  end
+
+  it 'fails if the if-none-exist extension is an empty string' do
+    card = base_card
+    card['suggestions'].first['actions'].first['extension'] = {
+      'davinci-crd.if-none-exist': ''
+    }
+    result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
+                           valid_system_actions: [].to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(entity_result_message.message).to match(/is an empty string/)
   end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/form_completion_response_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/form_completion_response_validation_test_spec.rb
@@ -82,14 +82,14 @@ RSpec.describe DaVinciCRDTestKit::V221::FormCompletionResponseValidationTest do
       'davinci-crd.if-none-exist': ['http://example.org/Questionnaire/XYZ']
     }
     result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
-                 valid_system_actions: [].to_json)
+                           valid_system_actions: [].to_json)
 
     expect(result.result).to eq('pass'), result.result_message
   end
 
   it 'fails if form creation actions do not include the if-none-exist extension' do
     result = run(runnable, valid_cards_with_suggestions: [base_card].to_json,
-                 valid_system_actions: [].to_json)
+                           valid_system_actions: [].to_json)
 
     expect(result.result).to eq('fail')
   end


### PR DESCRIPTION
# Summary
This branch adds a test for the if-none-exist extension (https://hl7.org/fhir/us/davinci-crd/2.2.1/en/deviations.html#if-none-exist) on questionnaire creation actions.

# Testing Guidance
In `lib/davinci_crd_test_kit/client/endpoints/mocked_card_responses/request_form_completion.json`, you can change the value of the `if-none-exist` extension to an array to make this check fail.

# Anticipated Provider-side Test Impact
None