### PR TITLE
ID-110: Verify client TLS usage

### DIFF
--- a/lib/davinci_crd_test_kit/client/multi_request_message_helper.rb
+++ b/lib/davinci_crd_test_kit/client/multi_request_message_helper.rb
@@ -1,0 +1,35 @@
+module DaVinciCRDTestKit
+  module MultiRequestMessageHelper
+    def request_prefix(request_index)
+      "(Request #{request_index + 1}) "
+    end
+
+    def add_request_message(type, message, request_index)
+      add_message(type, "#{request_prefix(request_index)}#{message}")
+    end
+
+    def parse_json_request_entity(body, entity, request_index)
+      JSON.parse(body)
+    rescue JSON::ParserError
+      add_request_message('error', "#{entity} contains invalid JSON.", request_index)
+      nil
+    end
+
+    def requests_with_errors_prefix
+      request_numbers = error_request_numbers
+      return '' if request_numbers.empty?
+
+      noun = request_numbers.size == 1 ? 'Request' : 'Requests'
+      "#{noun} #{request_numbers.to_sentence}: "
+    end
+
+    private
+
+    def error_request_numbers
+      messages
+        .select { |m| m[:type] == 'error' }
+        .filter_map { |m| m[:message].match(/\A\(Request (\d+)\)/)&.captures&.first&.to_i }
+        .sort.uniq
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/client/tagged_request_load_helper.rb
+++ b/lib/davinci_crd_test_kit/client/tagged_request_load_helper.rb
@@ -1,0 +1,19 @@
+module DaVinciCRDTestKit
+  module TaggedRequestLoadHelper
+    def hook_name
+      config.options[:hook_name]
+    end
+
+    def crd_test_group
+      config.options[:crd_test_group]
+    end
+
+    def tags_to_load
+      crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
+    end
+
+    def load_hook_requests
+      load_tagged_requests(*tags_to_load)
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/auth/decode_auth_token_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/auth/decode_auth_token_test.rb
@@ -1,9 +1,11 @@
-require_relative '../../client_hook_request_validation'
+require_relative '../../multi_request_message_helper'
+require_relative '../../tagged_request_load_helper'
 
 module DaVinciCRDTestKit
   module V221
     class DecodeAuthTokenTest < Inferno::Test
-      include ClientHookRequestValidation
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
       id :crd_v221_decode_auth_token
       title 'Bearer token can be decoded'
       description %(
@@ -16,24 +18,19 @@ module DaVinciCRDTestKit
 
       output :auth_tokens, :auth_token_payloads_json, :auth_token_headers_json
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
       run do
-        load_tagged_requests(hook_name)
+        load_hook_requests
         skip_if requests.empty?, "No #{hook_name} requests were made in a previous test as expected."
         auth_tokens = []
         auth_token_payloads_json = []
         auth_token_headers_json = []
 
         requests.each_with_index do |request, index|
-          @request_number = index + 1
-
           authorization_header = request.request_header('Authorization')&.value
 
-          unless authorization_header.start_with?('Bearer ')
-            add_message('error', "#{request_number}Authorization token must be a JWT presented as a `Bearer` token")
+          unless authorization_header&.start_with?('Bearer ')
+            add_request_message('error', 'Authorization token must be a JWT presented as a `Bearer` token', index)
+            next
           end
 
           auth_token = authorization_header.delete_prefix('Bearer ')
@@ -50,14 +47,15 @@ module DaVinciCRDTestKit
             auth_token_payloads_json << payload.to_json
             auth_token_headers_json << header.to_json
           rescue StandardError => e
-            add_message('error', "#{request_number}Token is not a properly constructed JWT: #{e.message}")
+            add_request_message('error', "Token is not a properly constructed JWT: #{e.message}", index)
           end
         end
         output auth_tokens: auth_tokens.to_json,
                auth_token_payloads_json: auth_token_payloads_json.to_json,
                auth_token_headers_json: auth_token_headers_json.to_json
 
-        no_error_validation('Decoding Authorization header Bearer tokens failed.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Decoding Authorization header Bearer tokens failed. " \
+                                 'See Messages for details')
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/auth/retrieve_jwks_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/auth/retrieve_jwks_test.rb
@@ -1,9 +1,9 @@
-require_relative '../../client_hook_request_validation'
+require_relative '../../multi_request_message_helper'
 
 module DaVinciCRDTestKit
   module V221
     class RetrieveJWKSTest < Inferno::Test
-      include ClientHookRequestValidation
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
 
       id :crd_v221_retrieve_jwks
       title 'JWKS can be retrieved'
@@ -32,67 +32,64 @@ module DaVinciCRDTestKit
       output :crd_jwks_json, :crd_jwks_keys_json
 
       run do
-        auth_token_headers = JSON.parse(auth_token_headers_json)
+        auth_token_headers = JSON.parse(auth_token_headers_json) # NOTE: pre-verified json
         skip_if auth_token_headers.empty?, 'No Authorization tokens produced from the previous test.'
 
         crd_jwks_json = []
         crd_jwks_keys_json = []
         auth_token_headers.each_with_index do |token_header, index|
-          @request_number = index + 1
-
-          jku = JSON.parse(token_header)['jku']
+          jku = JSON.parse(token_header)['jku'] # NOTE: pre-verified json
           if jku.present?
             get(jku)
 
             if response[:status] != 200
-              add_message('error', %(
-                        #{request_number}Unexpected response status: expected 200, but received
-                        #{response[:status]}))
+              add_request_message('error',
+                                  "Unexpected response status: expected 200, but received #{response[:status]}",
+                                  index)
               next
             end
 
-            @request_number = index + 1
-            jwks = json_parse(response[:body])
+            jwks = parse_json_request_entity(response[:body], 'Fetched jku url response', index)
             next if jwks.blank?
 
             crd_jwks_json << response[:body]
-
-            jwks = JSON.parse(response[:body])
           else
             skip_if cds_jwk_set.blank?,
-                    %(#{request_number}JWK Set must be inputted if Client's JWK Set is not available via a URL
-                  identified by the jku header field)
+                    "JWK Set must be inputted if Client's JWK Set is not available via a URL " \
+                    'identified by the jku header field'
 
-            jwks = JSON.parse(cds_jwk_set)
+            jwks = parse_json_request_entity(cds_jwk_set, 'JWK Set input', index)
+            next if jwks.blank?
           end
 
           keys = jwks['keys']
           unless keys.is_a?(Array)
-            add_message('error', "#{request_number}JWKS `keys` field must be an array")
+            add_request_message('error', 'JWKS `keys` field must be an array', index)
             next
           end
 
           if keys.blank?
-            add_message('error', "#{request_number}The JWK set returned contains no public keys")
+            add_request_message('error', 'The JWK set returned contains no public keys', index)
             next
           end
 
           keys.each do |jwk|
             JWT::JWK.import(jwk.deep_symbolize_keys)
           rescue StandardError
-            add_message('error', "#{request_number}Invalid JWK: #{jwk.to_json}")
+            add_request_message('error', "Invalid JWK: #{jwk.to_json}", index)
           end
 
           kid_presence = keys.all? { |key| key['kid'].present? }
           if kid_presence.blank?
-            add_message('error',
-                        "#{request_number}`kid` field must be present in each key if JWKS contains multiple keys")
+            add_request_message('error',
+                                '`kid` field must be present in each key if JWKS contains multiple keys',
+                                index)
             next
           end
 
           kid_uniqueness = keys.map { |key| key['kid'] }.uniq.length == keys.length
           if kid_uniqueness.blank?
-            add_message('error', "#{request_number}`kid` must be unique within the client's JWK Set.")
+            add_request_message('error', "`kid` must be unique within the client's JWK Set.", index)
             next
           end
 
@@ -102,7 +99,7 @@ module DaVinciCRDTestKit
         output crd_jwks_json: crd_jwks_json.to_json,
                crd_jwks_keys_json: crd_jwks_keys_json.to_json
 
-        no_error_validation('Retrieving JWKS failed.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Retrieving JWKS failed. See Messages for details.")
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/auth/token_header_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/auth/token_header_test.rb
@@ -1,9 +1,9 @@
-require_relative '../../client_hook_request_validation'
+require_relative '../../multi_request_message_helper'
 
 module DaVinciCRDTestKit
   module V221
     class TokenHeaderTest < Inferno::Test
-      include ClientHookRequestValidation
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
 
       id :crd_v221_token_header
       title 'Authorization token header contains required information'
@@ -27,34 +27,32 @@ module DaVinciCRDTestKit
 
         auth_tokens_jwk_json = []
         auth_token_headers.each_with_index do |token_header, index|
-          @request_number = index + 1
-
-          header = JSON.parse(token_header)
+          header = JSON.parse(token_header) # NOTE: pre-verified json
           algorithm = header['alg']
 
-          add_message('error', "#{request_number}Token header must have the `alg` field") if algorithm.blank?
+          add_request_message('error', 'Token header must have the `alg` field', index) if algorithm.blank?
 
-          add_message('error', "#{request_number}Token header `alg` field cannot be set to none") if algorithm == 'none'
+          add_request_message('error', 'Token header `alg` field cannot be set to none', index) if algorithm == 'none'
 
           if header['typ'].blank?
-            add_message('error', "#{request_number}Token header must have the `typ` field")
+            add_request_message('error', 'Token header must have the `typ` field', index)
           elsif header['typ'] != 'JWT'
-            add_message('error', %(
-                      #{request_number}Token header `typ` field must be set to 'JWT', instead was
-                      #{header['typ']}))
+            add_request_message('error',
+                                "Token header `typ` field must be set to 'JWT', instead was #{header['typ']}",
+                                index)
           end
 
           if header['kid'].blank?
-            add_message('error', "#{request_number}Token header must have the `kid` field")
+            add_request_message('error', 'Token header must have the `kid` field', index)
             next
           end
 
           kid = header['kid']
-          keys = JSON.parse(crd_jwks_keys[index])
+          keys = JSON.parse(crd_jwks_keys[index]) # NOTE: pre-verified json
 
           jwk = keys.find { |key| key['kid'] == kid }
           if jwk.blank?
-            add_message('error', "#{request_number}JWKS did not contain a public key with an id of `#{kid}`")
+            add_request_message('error', "JWKS did not contain a public key with an id of `#{kid}`", index)
             next
           end
 
@@ -63,7 +61,8 @@ module DaVinciCRDTestKit
 
         output auth_tokens_jwk_json: auth_tokens_jwk_json.to_json
 
-        no_error_validation('Token headers missing required information.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Token header missing required information. " \
+                                 'See Messages for details.')
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/auth/token_payload_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/auth/token_payload_test.rb
@@ -1,10 +1,11 @@
-require_relative '../../client_hook_request_validation'
+require_relative '../../multi_request_message_helper'
 
 module DaVinciCRDTestKit
   module V221
     class TokenPayloadTest < Inferno::Test
-      include ClientHookRequestValidation
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
       include ClientURLs
+
       id :crd_v221_token_payload
       title 'Authorization token payload has required claims and a valid signature'
       description %(
@@ -44,10 +45,8 @@ module DaVinciCRDTestKit
         skip_if auth_tokens_jwk.empty?, 'No Authorization token JWK produced from the previous test.'
 
         auth_tokens_jwk.each_with_index do |auth_token_jwk, index|
-          @request_number = index + 1
-
           begin
-            jwk = JSON.parse(auth_token_jwk).deep_symbolize_keys
+            jwk = JSON.parse(auth_token_jwk).deep_symbolize_keys # NOTE: pre-verified json
 
             payload, =
               JWT.decode(
@@ -65,7 +64,7 @@ module DaVinciCRDTestKit
                 verify_aud: true
               )
           rescue StandardError => e
-            add_message('error', "#{request_number}Token validation error: #{e.message}")
+            add_request_message('error', "Token validation error: #{e.message}", index)
             next
           end
 
@@ -73,11 +72,12 @@ module DaVinciCRDTestKit
           missing_claims_string = missing_claims.map { |claim| "`#{claim}`" }.join(', ')
 
           unless missing_claims.empty?
-            add_message('error', "#{request_number}JWT payload missing required claims: #{missing_claims_string}")
+            add_request_message('error', "JWT payload missing required claims: #{missing_claims_string}", index)
             next
           end
         end
-        no_error_validation('Token payload is missing required claims or does not have a valid signiture.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Token payload is missing required claims or " \
+                                 'does not have a valid signature. See Messages for details.')
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_appointment_book_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
+require_relative 'verify_request/hook_request_secured_transport_test'
 require_relative 'verify_request/hook_request_coverage_verification_test'
 require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
@@ -86,6 +87,7 @@ module DaVinciCRDTestKit
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification
         test from: :crd_v221_hook_request_granted_scopes
+        test from: :crd_v221_hook_request_secured_transport
 
         # TODO: migrate requirements
         # test from: :crd_v221_hook_request_required_fields

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_discharge_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
+require_relative 'verify_request/hook_request_secured_transport_test'
 require_relative 'verify_request/hook_request_coverage_verification_test'
 require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
@@ -86,6 +87,7 @@ module DaVinciCRDTestKit
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification
         test from: :crd_v221_hook_request_granted_scopes
+        test from: :crd_v221_hook_request_secured_transport
 
         # TODO: migrate requirements
         # test from: :crd_v221_hook_request_required_fields

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_start_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
+require_relative 'verify_request/hook_request_secured_transport_test'
 require_relative 'verify_request/hook_request_coverage_verification_test'
 require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
@@ -86,6 +87,7 @@ module DaVinciCRDTestKit
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification
         test from: :crd_v221_hook_request_granted_scopes
+        test from: :crd_v221_hook_request_secured_transport
 
         # TODO: migrate requirements
         # test from: :crd_v221_hook_request_required_fields

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_dispatch_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
+require_relative 'verify_request/hook_request_secured_transport_test'
 require_relative 'verify_request/hook_request_coverage_verification_test'
 require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
@@ -85,6 +86,7 @@ module DaVinciCRDTestKit
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification
         test from: :crd_v221_hook_request_granted_scopes
+        test from: :crd_v221_hook_request_secured_transport
 
         # TODO: migrate requirements
         # test from: :crd_v221_hook_request_required_fields

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_select_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
+require_relative 'verify_request/hook_request_secured_transport_test'
 require_relative 'verify_request/hook_request_coverage_verification_test'
 require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
@@ -87,6 +88,7 @@ module DaVinciCRDTestKit
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification
         test from: :crd_v221_hook_request_granted_scopes
+        test from: :crd_v221_hook_request_secured_transport
 
         # TODO: migrate requirements
         # test from: :crd_v221_hook_request_required_fields

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
@@ -8,6 +8,7 @@ require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
+require_relative 'verify_request/hook_request_secured_transport_test'
 require_relative 'verify_request/hook_request_coverage_verification_test'
 require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
@@ -86,6 +87,7 @@ module DaVinciCRDTestKit
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification
         test from: :crd_v221_hook_request_granted_scopes
+        test from: :crd_v221_hook_request_secured_transport
 
         # TODO: migrate requirements
         # test from: :crd_v221_hook_request_required_fields

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_conformance_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_conformance_test.rb
@@ -1,9 +1,13 @@
 require_relative '../../../cross_suite/requests_logical_model_validation'
+require_relative '../../tagged_request_load_helper'
+require_relative '../../multi_request_message_helper'
 
 module DaVinciCRDTestKit
   module V221
     class HookRequestConformanceTest < Inferno::Test
       include RequestsLogicalModelValidation
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
 
       id :crd_v221_hook_request_conformance
       title 'Hook request conforms to required logical model'
@@ -17,25 +21,13 @@ module DaVinciCRDTestKit
       #                       'cds-hooks_2.0@23', 'cds-hooks_2.0@65', 'cds-hooks_2.0@66', 'cds-hooks_2.0@67',
       #                       'cds-hooks_2.0@68', 'cds-hooks_2.0@69', 'cds-hooks_2.0@70'
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
       run do
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 
         hook_requests.each_with_index do |request, request_index|
-          request_body = parsed_json_if_valid(request.request_body)
+          request_body = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless request_body.present?
 
           validate_request_against_logical_model(request_body, request_index, '2.2.1')
@@ -46,7 +38,7 @@ module DaVinciCRDTestKit
           end
         end
 
-        assert_no_error_messages('Non-conformant hook requests detected. See Messages for details.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Non-conformant hook request. See Messages for details.")
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_coverage_verification_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_coverage_verification_test.rb
@@ -1,8 +1,12 @@
 require_relative '../../../cross_suite/tags'
+require_relative '../../multi_request_message_helper'
+require_relative '../../tagged_request_load_helper'
 
 module DaVinciCRDTestKit
   module V221
     class HookRequestCoverageVerficationTest < Inferno::Test
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
       id :crd_v221_hook_request_coverage_verification
       title 'Hook request coverages are valid'
       description %(
@@ -24,88 +28,71 @@ module DaVinciCRDTestKit
             optional: true,
             locked: true
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
-      def request_prefix
-        if @request_number.blank?
-          ''
-        else
-          "(Request #{@request_number}) "
-        end
-      end
-
       def load_payer_request_for_hook_request(request_body)
         hook_tag = "#{HOOK_INSTANCE_TAG_PREFIX}#{request_body['hookInstance']}"
         load_tagged_requests('payer', hook_tag, DATA_FETCH_TAG).first
       end
 
-      def check_payer_request(request_body)
+      def check_payer_request(request_body, request_index)
         payer_request = load_payer_request_for_hook_request(request_body)
         unless payer_request.present? && payer_request.status.to_s.starts_with?('2')
-          add_message('error',
-                      "#{request_prefix}Inferno failed to retrieve the Coverage's payer during hook processing.")
+          add_request_message('error',
+                              "Inferno failed to retrieve the Coverage's payer during hook processing.",
+                              request_index)
           return
         end
 
         payer_resource = FHIR.from_contents(payer_request.response_body)
         unless payer_resource.present?
-          add_message('error', "#{request_prefix}Request for payer resource returned invalid FHIR data.")
+          add_request_message('error', 'Request for payer resource returned invalid FHIR data.', request_index)
           return
         end
 
         if payer_resource.resourceType != 'Organization'
-          add_message('error', "#{request_prefix}Payer for the Coverage is not an Organization: " \
-                               "got '#{payer_resource.resourceType}'")
+          add_request_message('error', 'Payer for the Coverage is not an Organization: ' \
+                                       "got '#{payer_resource.resourceType}'", request_index)
         end
         if payer_resource.id != inferno_payer_organization_id
-
-          add_message('error', "#{request_prefix}Payer for the Coverage has the wrong id: " \
-                               "expected '#{inferno_payer_organization_id}', got '#{payer_resource.id}'.")
+          add_request_message('error', 'Payer for the Coverage has the wrong id: ' \
+                                       "expected '#{inferno_payer_organization_id}', got '#{payer_resource.id}'.",
+                              request_index)
         end
 
-        resource_is_valid?(resource: payer_resource, profile_url: 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-organization|2.2.1')
+        validator_response_details = []
+        resource_is_valid?(resource: payer_resource, profile_url: 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-organization|2.2.1',
+                           add_messages_to_runnable: false, validator_response_details:)
+
+        validator_response_details.each { |issue| add_request_message(issue.severity, issue.message, request_index) }
       end
 
       run do
         skip_if inferno_payer_organization_id.blank?,
                 'Input "Inferno Payer Organization id " is needed to verify behavior.'
 
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 
         hook_requests.each_with_index do |request, request_index|
-          @request_number = request_index + 1
-
-          request_body = parsed_json_if_valid(request.request_body, "#{request_prefix} Request body malformed.")
+          request_body = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless request_body.present?
 
           coverage = request_body.dig('prefetch', 'coverage', 'entry', 0, 'resource')
           unless coverage.present?
-            add_message('warning', "#{request_prefix}Request has no coverage.")
+            add_request_message('warning', 'Request has no coverage.', request_index)
             next
           end
 
           payer_organization_reference = coverage.dig('payor', 0, 'reference')
           if payer_organization_reference.blank?
-            add_message('error', "#{request_prefix}Coverage has no payer reference.")
+            add_request_message('error', 'Coverage has no payer reference.', request_index)
             next
           end
 
-          check_payer_request(request_body)
+          check_payer_request(request_body, request_index)
         end
 
-        assert_no_error_messages('Some hook requests contain invalid coverages. ' \
+        assert_no_error_messages("#{requests_with_errors_prefix}Invalid coverage. " \
                                  'See Messages for details.')
       end
     end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_data_fetch_verification_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_data_fetch_verification_test.rb
@@ -1,8 +1,10 @@
 require_relative '../../../cross_suite/tags'
+require_relative '../../tagged_request_load_helper'
 
 module DaVinciCRDTestKit
   module V221
     class HookRequestDataFetchVerificationTest < Inferno::Test
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
       id :crd_v221_hook_data_fetch_verification
       title 'Additional FHIR data could be requested during hook request processing'
       description %(
@@ -14,18 +16,6 @@ module DaVinciCRDTestKit
         all hook requestsmust have been successful and returned at least one
         FHIR resource.
       )
-
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
 
       def fhir_data_returned?(request)
         return false unless request.status.to_s.starts_with?('2')
@@ -43,7 +33,7 @@ module DaVinciCRDTestKit
       end
 
       run do
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_granted_scopes_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_granted_scopes_test.rb
@@ -1,8 +1,12 @@
+require_relative '../../multi_request_message_helper'
 require_relative '../../crd_client_options'
+require_relative '../../tagged_request_load_helper'
 
 module DaVinciCRDTestKit
   module V221
     class HookRequestGrantedScopesTest < Inferno::Test
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
       id :crd_v221_hook_request_granted_scopes
       title 'Hook requests grant the requested scopes'
       description %(
@@ -18,45 +22,24 @@ module DaVinciCRDTestKit
         provided for those tests.
       )
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
-      def request_prefix
-        if @request_number.blank?
-          ''
-        else
-          "(Request #{@request_number}) "
-        end
-      end
-
       run do
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 
         hook_requests.each_with_index do |request, request_index|
-          @request_number = request_index + 1
-
-          request_body = parsed_json_if_valid(request.request_body)
+          request_body = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless request_body.present?
 
           # check that the resource scopes match what Inferno requested
           granted_resource_scopes = granted_resource_scopes(request_body)
-          check_granted_resources(granted_resource_scopes)
-          check_granted_scopes_level(granted_resource_scopes)
-          check_granted_interactions(granted_resource_scopes)
+          check_granted_resources(granted_resource_scopes, request_index)
+          check_granted_scopes_level(granted_resource_scopes, request_index)
+          check_granted_interactions(granted_resource_scopes, request_index)
         end
 
-        assert_no_error_messages('Granted scopes do not match what was requested. See Messages for details.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Granted scopes do not match the requested scopes. " \
+                                 'See Messages for details.')
       end
 
       def requested_scope_resources
@@ -75,49 +58,49 @@ module DaVinciCRDTestKit
         granted_scopes.split(' ').grep(%r{\A\S+/\S+\.\S+\z}) # rubocop:disable Style/RedundantArgument
       end
 
-      def check_granted_resources(granted_resource_scopes)
+      def check_granted_resources(granted_resource_scopes, request_index)
         granted_scope_resources = granted_resource_scopes.map { |scope| scope.split('/').last.split('.').first }
 
         missing_resources = requested_scope_resources - granted_scope_resources
         extra_resources = granted_scope_resources - requested_scope_resources
         if missing_resources.present?
-          add_message('error', "#{request_prefix} Granted scopes missing the following " \
-                               "requested resource types: #{missing_resources.join(', ')}")
+          add_request_message('error', 'Granted scopes missing the following ' \
+                                       "requested resource types: #{missing_resources.join(', ')}", request_index)
         end
-        if extra_resources.present?
-          add_message('error', "#{request_prefix} Granted scopes included the following resource types " \
-                               "beyond what was requested: #{extra_resources.join(', ')}")
-        end
+        return unless extra_resources.present?
 
-        nil
+        add_request_message('error', 'Granted scopes included the following resource types ' \
+                                     "beyond what was requested: #{extra_resources.join(', ')}", request_index)
       end
 
-      def check_granted_interactions(granted_resource_scopes)
+      def check_granted_interactions(granted_resource_scopes, request_index)
         return if granted_resource_scopes.all? { |scope| scope.split('.').last == 'rs' }
 
         if granted_resource_scopes.all? { |scope| scope.split('.').last == 'read' }
-          add_message('warning',
-                      "#{request_prefix} SMART v1 `read` scope used. Use of SMART v2 `rs` scope recommended.")
+          add_request_message('warning',
+                              'SMART v1 `read` scope used. Use of SMART v2 `rs` scope recommended.',
+                              request_index)
           return
         end
 
-        add_message('error', "#{request_prefix} Some granted resource scopes do not provide " \
-                             "requested 'rs' (read and search) interactions.")
+        add_request_message('error', 'Some granted resource scopes do not provide ' \
+                                     "requested 'rs' (read and search) interactions.", request_index)
       end
 
-      def check_granted_scopes_level(granted_resource_scopes)
+      def check_granted_scopes_level(granted_resource_scopes, request_index)
         level = scopes_level(granted_resource_scopes)
         if level.blank?
-          add_message('error',
-                      "#{request_prefix} Requested scopes did not use a consistent level of scope (patient or user).")
+          add_request_message('error',
+                              'Requested scopes did not use a consistent level of scope (patient or user).',
+                              request_index)
           return
         end
 
         return if ['user', 'patient'].include?(level)
 
-        add_message('error',
-                    "#{request_prefix} Unexpected level for granted scopes: " \
-                    "expected 'user' or 'patient', got '#{level}'.")
+        add_request_message('error',
+                            "Unexpected level for granted scopes: expected 'user' or 'patient', got '#{level}'.",
+                            request_index)
       end
 
       def scopes_level(granted_resource_scopes)
@@ -127,14 +110,7 @@ module DaVinciCRDTestKit
       end
 
       def all_scopes_same_level?(granted_resource_scopes)
-        return true unless granted_resource_scopes.present?
-
-        level = granted_resource_scopes.first.split('/').first
-        granted_resource_scopes.each do |scope|
-          return false if scope.split('/').first != level
-        end
-
-        true
+        granted_resource_scopes.map { |s| s.split('/').first }.uniq.size <= 1
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_complete_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_complete_test.rb
@@ -1,8 +1,12 @@
 require_relative '../../../cross_suite/prefetch_completeness_checker'
+require_relative '../../tagged_request_load_helper'
+require_relative '../../multi_request_message_helper'
 
 module DaVinciCRDTestKit
   module V221
     class HookRequestPrefetchCompleteTest < Inferno::Test
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
       id :crd_v221_hook_request_prefetch_complete
       title 'Hook request contains complete prefetched data set'
       description %(
@@ -23,36 +27,24 @@ module DaVinciCRDTestKit
       )
       # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@54', 'cds-hooks_2.0@30', 'cds-hooks_2.0@47'
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
       run do
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 
         hook_requests.each_with_index do |request, request_index|
-          hook_request = parsed_json_if_valid(request.request_body,
-                                              "#{hook_name} request #{request_index + 1} malformed.")
+          hook_request = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless hook_request.present?
 
           services_path = File.join(__dir__, '..', 'cds-services-v221.json')
           PrefetchCompletenessChecker.new(hook_request, request_index,
                                           services_path).check_prefetched_data.each do |error|
-            add_message('error', error)
+            add_message('error', error) # NOTE: PrefetchCompletenessChecker adds the (Request #) prefix
           end
         end
 
-        assert_no_error_messages('Prefetch is not valid.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Incomplete or invalid prefetched data. " \
+                                 'See Messages for details.')
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_profiles_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_profiles_test.rb
@@ -1,9 +1,13 @@
 require_relative '../../../cross_suite/prefetch_profile_validation'
+require_relative '../../tagged_request_load_helper'
+require_relative '../../multi_request_message_helper'
 
 module DaVinciCRDTestKit
   module V221
     class HookRequestPrefetchProfilesTest < Inferno::Test
       include PrefetchProfileValidation
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
 
       id :crd_v221_hook_request_prefetch_profiles
       title 'Prefetched data conforms to required CRD profiles'
@@ -21,34 +25,21 @@ module DaVinciCRDTestKit
       )
       # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@54', 'cds-hooks_2.0@30', 'cds-hooks_2.0@47'
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
       run do
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 
         hook_requests.each_with_index do |request, request_index|
-          @request_index = request_index
-          hook_request = parsed_json_if_valid(request.request_body,
-                                              "#{hook_name} request #{request_index + 1} malformed.")
+          hook_request = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless hook_request.present?
           next unless hook_request.key?('prefetch')
 
-          check_prefetch_profiles(hook_request['prefetch'])
+          check_prefetch_profiles(hook_request['prefetch'], request_index)
         end
 
-        assert_no_error_messages('Prefetched resources do not all conform to CRD profiles.')
+        assert_no_error_messages("#{requests_with_errors_prefix}Prefetched data not conformant to CRD profiles. " \
+                                 'See Messages for details.')
       end
     end
   end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_requested_version_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_requested_version_test.rb
@@ -1,6 +1,12 @@
+require_relative '../../multi_request_message_helper'
+require_relative '../../tagged_request_load_helper'
+
 module DaVinciCRDTestKit
   module V221
-    class HookRequestExtensionsTest < Inferno::Test
+    class HookRequestRequestedVersionTest < Inferno::Test
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
+
       id :crd_v221_hook_request_requested_version
       title 'Hook request contains the CRD version extension'
       description %(
@@ -12,52 +18,33 @@ module DaVinciCRDTestKit
       #                       'cds-hooks_2.0@23', 'cds-hooks_2.0@65', 'cds-hooks_2.0@66', 'cds-hooks_2.0@67',
       #                       'cds-hooks_2.0@68', 'cds-hooks_2.0@69', 'cds-hooks_2.0@70'
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
-      def request_number
-        if @request_number.blank?
-          ''
-        else
-          "(Request #{@request_number}) "
-        end
-      end
-
       run do
-        hook_requests = load_tagged_requests(*tags_to_load)
+        hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
 
         hook_requests.each_with_index do |request, request_index|
-          @request_number = request_index + 1
-
-          request_body = parsed_json_if_valid(request.request_body)
+          request_body = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless request_body.present?
 
           requested_version = request_body.dig('extension', 'davinci-crd.requestedVersion')
           if requested_version.blank?
-            add_message('error', "#{request_number} Required extension 'davinci-crd.requestedVersion' is not present.")
+            add_request_message('error', "Required extension 'davinci-crd.requestedVersion' is not present.",
+                                request_index)
           elsif !requested_version.is_a?(String)
-            add_message('error',
-                        "#{request_number} For extension 'davinci-crd.requestedVersion' expected a String, " \
-                        "got #{requested_version.class}")
+            add_request_message('error',
+                                "For extension 'davinci-crd.requestedVersion' expected a String, " \
+                                "got #{requested_version.class}",
+                                request_index)
           elsif requested_version != '2.2'
-            add_message('error',
-                        "#{request_number} For extension 'davinci-crd.requestedVersion' expected '2.2', " \
-                        "got '#{requested_version}'")
+            add_request_message('error',
+                                "For extension 'davinci-crd.requestedVersion' expected '2.2', " \
+                                "got '#{requested_version}'",
+                                request_index)
           end
         end
 
-        assert_no_error_messages('Some hook requests did not populate the requested version extension properly. ' \
+        assert_no_error_messages("#{requests_with_errors_prefix}Requested version extension not populated properly. " \
                                  'See Messages for details.')
       end
     end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_secured_transport_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_secured_transport_test.rb
@@ -1,0 +1,47 @@
+require_relative '../../multi_request_message_helper'
+require_relative '../../tagged_request_load_helper'
+
+module DaVinciCRDTestKit
+  module V221
+    class HookRequestSecuredTransportTest < Inferno::Test
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
+
+      id :crd_v221_hook_request_secured_transport
+      title 'Hook request interactions use TLS'
+      description %(
+        CRD and the underlying CDS Hooks specification require the use of TLS to protect
+        information passed between the client and service. This test verifies that
+        requests made by both the client and Inferno's simulated service are made against
+        TLS-secured endpoints using the `https` protocol.
+      )
+
+      run do
+        hook_requests = load_hook_requests
+
+        skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
+
+        hook_requests.each_with_index do |request, request_index|
+          unless request.url.starts_with?('https')
+            add_request_message('error',
+                                "Inferno's simulated CRD Service must use the https " \
+                                'protocol (TLS). Run this suite on a host that uses TLS.',
+                                request_index)
+          end
+
+          # check that the fhirServer endpoint uses https
+          request_body = parse_json_request_entity(request.request_body, 'Request body', request_index)
+          next unless request_body.present?
+          next unless request_body['fhirServer'].present? && !request_body['fhirServer'].starts_with?('https')
+
+          add_request_message('error',
+                              'The `fhirServer` provided in the request must use the https protocol (TLS).',
+                              request_index)
+        end
+
+        assert_no_error_messages("#{requests_with_errors_prefix}Interactions not secured using TLS. " \
+                                 'See Messages for details.')
+      end
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_response/client_display_cards_attest.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_response/client_display_cards_attest.rb
@@ -1,11 +1,13 @@
 require_relative '../client_urls'
 require_relative '../../../cross_suite/cards_identification'
+require_relative '../../tagged_request_load_helper'
 
 module DaVinciCRDTestKit
   module V221
     class ClientCardDisplayAttest < Inferno::Test
       include ClientURLs
       include CardsIdentification
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
 
       id :crd_v221_card_display_attest_test
       title 'Check that returned decision support details are displayed to the user'
@@ -15,18 +17,6 @@ module DaVinciCRDTestKit
         to the user in an appopriate way that allows for consideration and action
         if warranted.
       )
-
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
 
       def responded_card_types
         list_card_types_in_requests(requests)
@@ -54,7 +44,7 @@ module DaVinciCRDTestKit
       output :attest_false_url
 
       run do
-        load_tagged_requests(*tags_to_load)
+        load_hook_requests
         skip_if responded_card_types.blank?, 'No responses sent to the client.'
 
         identifier = SecureRandom.hex(32)

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_response/inferno_response_validation.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_response/inferno_response_validation.rb
@@ -1,11 +1,13 @@
 require_relative '../../../cross_suite/cards_validation'
 require_relative '../../../cross_suite/cards_logical_model_validation'
+require_relative '../../tagged_request_load_helper'
 
 module DaVinciCRDTestKit
   module V221
     class InfernoResponseValidationTest < Inferno::Test
       include CardsValidation
       include CardsLogicalModelValidation
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
 
       title 'Inferno CDS Service Response is Conformant'
       description %(
@@ -25,18 +27,6 @@ module DaVinciCRDTestKit
 
       input :custom_response_template, optional: true
 
-      def hook_name
-        config.options[:hook_name]
-      end
-
-      def crd_test_group
-        config.options[:crd_test_group]
-      end
-
-      def tags_to_load
-        crd_test_group.present? ? [hook_name, crd_test_group] : [hook_name]
-      end
-
       def response_label(index = nil)
         response_type = (custom_response_template.present? ? 'Custom built' : 'Mocked')
         "#{response_type} response#{index.present? ? " #{index}" : ''}"
@@ -49,7 +39,7 @@ module DaVinciCRDTestKit
       end
 
       run do
-        load_tagged_requests(*tags_to_load)
+        load_hook_requests
 
         skip_if request.blank?, "No #{response_label.downcase}s to verify."
 
@@ -69,7 +59,7 @@ module DaVinciCRDTestKit
         skip_if !entity_validated,
                 "No #{response_label.downcase} cards or system actions to verify returned by Inferno."
 
-        no_error_validation("Invalid Inferno #{response_label.downcase}(s). Check messages for issues found.")
+        no_error_validation("Invalid Inferno #{response_label.downcase}(s). See Messages for details.")
       end
     end
   end

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_profile_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_profile_validation.rb
@@ -4,31 +4,28 @@ module DaVinciCRDTestKit
   module PrefetchProfileValidation
     include HookRequestFieldValidation
 
-    def check_prefetch_profiles(prefetch)
+    def check_prefetch_profiles(prefetch, request_index)
       prefetch.each do |key, prefetched_resource|
         next unless prefetched_resource.present? # prefetch must be null if no data matches the template
 
         @prefetch_template = key
-        @bundle_entry_index = nil
-        check_resource_profile(prefetched_resource)
+        check_resource_profile(prefetched_resource, request_index, nil)
       end
     end
 
     private
 
-    def check_resource_profile(prefetched_resource)
+    def check_resource_profile(prefetched_resource, request_index, bundle_entry_index)
       if prefetched_resource['resourceType'] == 'Bundle'
-        prefetched_resource['entry']&.each_with_index do |entry, bundle_entry_index|
-          @bundle_entry_index = bundle_entry_index
-          check_resource_profile(entry['resource']) if entry['resource'].present?
+        prefetched_resource['entry']&.each_with_index do |entry, entry_index|
+          check_resource_profile(entry['resource'], request_index, entry_index) if entry['resource'].present?
         end
-        @bundle_entry_index = nil
       elsif prefetched_resource['resourceType'].present?
-        check_non_bundle_resource_profile(prefetched_resource)
+        check_non_bundle_resource_profile(prefetched_resource, request_index, bundle_entry_index)
       end
     end
 
-    def check_non_bundle_resource_profile(prefetched_resource)
+    def check_non_bundle_resource_profile(prefetched_resource, request_index, bundle_entry_index)
       target_crd_profile = structure_definition_map('v221')[prefetched_resource['resourceType']]
       return unless target_crd_profile.present?
 
@@ -37,13 +34,14 @@ module DaVinciCRDTestKit
                          profile_url: target_crd_profile,
                          validator_response_details: validation_details, add_messages_to_runnable: false)
       validation_details.each do |issue|
-        add_message(issue.severity, "#{prefetch_profile_error_prefix}#{issue.message}")
+        prefix = prefetch_profile_error_prefix(request_index, bundle_entry_index)
+        add_message(issue.severity, "#{prefix}#{issue.message}")
       end
     end
 
-    def prefetch_profile_error_prefix
-      prefix = "(Request #{@request_index + 1}) Prefetch Template '#{@prefetch_template}'"
-      prefix = " #{prefix} Bundle entry #{@bundle_entry_index + 1}" if @bundle_entry_index.present?
+    def prefetch_profile_error_prefix(request_index, bundle_entry_index)
+      prefix = "(Request #{request_index + 1}) Prefetch Template '#{@prefetch_template}'"
+      prefix = "#{prefix} Bundle entry #{bundle_entry_index + 1}" if bundle_entry_index.present?
       "#{prefix} validation issue - "
     end
   end

--- a/spec/davinci_crd_test_kit/prefetch_profile_validation_spec.rb
+++ b/spec/davinci_crd_test_kit/prefetch_profile_validation_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
       def initialize
         @messages = []
         @resource_is_valid_calls = []
-        @request_index = 0
       end
 
       def add_message(type, message)
@@ -44,7 +43,7 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
 
   describe '#check_prefetch_profiles' do
     it 'skips nil prefetch values' do
-      module_instance.check_prefetch_profiles({ 'patient' => nil })
+      module_instance.check_prefetch_profiles({ 'patient' => nil }, 0)
 
       expect(module_instance.resource_is_valid_calls).to be_empty
       expect(module_instance.messages).to be_empty
@@ -52,19 +51,19 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
 
     it 'validates each non-nil prefetch value' do
       module_instance.check_prefetch_profiles({ 'patient' => patient_resource,
-                                                'practitioner' => practitioner_resource })
+                                                'practitioner' => practitioner_resource }, 0)
 
       expect(module_instance.resource_is_valid_calls.size).to eq(2)
     end
 
     it 'skips prefetch values without a resourceType (not FHIR resources)' do
-      module_instance.check_prefetch_profiles({ 'patient' => { 'not' => 'FHIR' } })
+      module_instance.check_prefetch_profiles({ 'patient' => { 'not' => 'FHIR' } }, 0)
 
       expect(module_instance.resource_is_valid_calls).to be_empty
     end
 
     it 'skips resources with no associated CRD profile' do
-      module_instance.check_prefetch_profiles({ 'sd' => { 'resourceType' => 'StructureDefinition' } })
+      module_instance.check_prefetch_profiles({ 'sd' => { 'resourceType' => 'StructureDefinition' } }, 0)
 
       expect(module_instance.resource_is_valid_calls).to be_empty
     end
@@ -72,14 +71,14 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
 
   describe 'Bundle handling' do
     it 'validates each entry in the bundle individually' do
-      module_instance.check_prefetch_profiles({ 'patient' => patient_bundle })
+      module_instance.check_prefetch_profiles({ 'patient' => patient_bundle }, 0)
 
       expect(module_instance.resource_is_valid_calls.size).to eq(2)
     end
 
     it 'skips bundle entries without a resource' do
       bundle = { 'resourceType' => 'Bundle', 'entry' => [{ 'resource' => nil }, { 'resource' => patient_resource }] }
-      module_instance.check_prefetch_profiles({ 'patient' => bundle })
+      module_instance.check_prefetch_profiles({ 'patient' => bundle }, 0)
 
       expect(module_instance.resource_is_valid_calls.size).to eq(1)
     end
@@ -88,7 +87,7 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
   describe 'error message format' do
     it 'includes the request number and prefetch template key for single resource issues' do
       module_instance.issues_to_return = [error_issue]
-      module_instance.check_prefetch_profiles({ 'patient' => patient_resource })
+      module_instance.check_prefetch_profiles({ 'patient' => patient_resource }, 0)
 
       expect(module_instance.messages.first[:message])
         .to eq("(Request 1) Prefetch Template 'patient' validation issue - something went wrong")
@@ -96,7 +95,7 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
 
     it 'includes the bundle entry number for issues within a bundle' do
       module_instance.issues_to_return = [error_issue]
-      module_instance.check_prefetch_profiles({ 'patient' => patient_bundle })
+      module_instance.check_prefetch_profiles({ 'patient' => patient_bundle }, 0)
 
       messages = module_instance.messages.map { |m| m[:message] }
       expect(messages.first).to include('Bundle entry 1')
@@ -105,7 +104,7 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
 
     it 'passes the issue severity through to add_message' do
       module_instance.issues_to_return = [warning_issue]
-      module_instance.check_prefetch_profiles({ 'patient' => patient_resource })
+      module_instance.check_prefetch_profiles({ 'patient' => patient_resource }, 0)
 
       expect(module_instance.messages.first[:type]).to eq('warning')
     end
@@ -113,7 +112,7 @@ RSpec.describe DaVinciCRDTestKit::PrefetchProfileValidation do
 
   describe 'resource_is_valid? call' do
     it 'passes the correct CRD profile URL for the resource type' do
-      module_instance.check_prefetch_profiles({ 'patient' => patient_resource })
+      module_instance.check_prefetch_profiles({ 'patient' => patient_resource }, 0)
 
       call = module_instance.resource_is_valid_calls.first
       expect(call[:profile_url])

--- a/spec/davinci_crd_test_kit/v2.2.1/decode_auth_token_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/decode_auth_token_test_spec.rb
@@ -1,0 +1,121 @@
+require_relative '../../../lib/davinci_crd_test_kit/client/v2.2.1/auth/decode_auth_token_test'
+require_relative '../../../lib/davinci_crd_test_kit/server/jwt_helper'
+
+RSpec.describe DaVinciCRDTestKit::V221::DecodeAuthTokenTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:runnable) { Inferno::Repositories::Tests.new.find('crd_v221_decode_auth_token') }
+
+  let(:example_client_url) { 'https://cds.example.org' }
+  let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
+  let(:appointment_book_url) { "#{base_url}/cds-services/appointment-book-service" }
+
+  let(:appointment_book_hook_request) do
+    File.read(File.join(
+                __dir__, '..', '..', 'fixtures', 'appointment_book_hook_request.json'
+              ))
+  end
+
+  def create_appointment_hook_request(body: nil, status: 200, headers: nil, auth_header: nil)
+    headers ||= [
+      {
+        type: 'request',
+        name: 'Authorization',
+        value: auth_header
+      }
+    ]
+    repo_create(
+      :request,
+      name: 'appointment_book',
+      direction: 'incoming',
+      url: 'http://example.com/custom/crd_client/cds-services/appointment-book-service',
+      test_session_id: test_session.id,
+      request_body: body.is_a?(Hash) ? body.to_json : body,
+      result:,
+      status:,
+      headers:,
+      tags: ['appointment-book']
+    )
+  end
+
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+      .first
+  end
+
+  describe 'Appointment Book Decode Auth Token Test' do
+    let(:test) do
+      Class.new(DaVinciCRDTestKit::V221::DecodeAuthTokenTest) do
+        config(
+          options: { hook_name: 'appointment-book' }
+        )
+      end
+    end
+
+    it 'passes if valid authorization header included in request' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes if multiple requests have valid authorization headers' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if one of many requests has an invalid authorization headers' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: "Bearer #{token}")
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: token)
+
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(
+        /\(Request 2\) Authorization token must be a JWT presented as a `Bearer` token/
+      )
+    end
+
+    it 'fails if authorization header does not present the JWT as a `Bearer` token' do
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      create_appointment_hook_request(body: appointment_book_hook_request, auth_header: token)
+
+      result = run(test)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/Authorization token must be a JWT presented as a `Bearer` token/)
+    end
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_conformance_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_conformance_test_spec.rb
@@ -67,6 +67,6 @@ RSpec.describe DaVinciCRDTestKit::V221::HookRequestConformanceTest do
     result = run(test)
 
     expect(result.result).to eq('fail')
-    expect(result.result_message).to match(/Non-conformant hook requests detected/)
+    expect(result.result_message).to match(/Non-conformant hook request/)
   end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_requested_version_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_requested_version_test_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_requested_version_test'
 
-RSpec.describe DaVinciCRDTestKit::V221::HookRequestExtensionsTest do
+RSpec.describe DaVinciCRDTestKit::V221::HookRequestRequestedVersionTest do
   let(:suite_id) { 'crd_client_v221' }
   let(:runnable) { described_class }
   let(:results_repo) { Inferno::Repositories::Results.new }
@@ -104,7 +104,7 @@ RSpec.describe DaVinciCRDTestKit::V221::HookRequestExtensionsTest do
     create_hook_request(body: 'not valid json')
     result = run(test)
     expect(result.result).to eq('fail')
-    expect(entity_result_message.message).to match(/Invalid JSON/)
+    expect(entity_result_message.message).to match(/Request body contains invalid JSON./)
   end
 
   describe 'when a crd_test_group is configured' do

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_secured_transport_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_secured_transport_test_spec.rb
@@ -1,0 +1,95 @@
+require_relative '../../../lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_secured_transport_test'
+
+RSpec.describe DaVinciCRDTestKit::V221::HookRequestSecuredTransportTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
+
+  let(:test) do
+    Class.new(described_class) do
+      config(options: { hook_name: 'appointment-book' })
+    end
+  end
+
+  def create_hook_request(url: 'https://example.com/cds-services/appointment-book-service',
+                          fhir_server: 'https://fhir.example.com',
+                          tags: ['appointment-book'])
+    body = {
+      'hookInstance' => 'd1577c69-dfbe-44ad-ba6d-3e05e953b2ea',
+      'hook' => 'appointment-book',
+      'fhirServer' => fhir_server
+    }.compact
+    repo_create(
+      :request,
+      direction: 'incoming',
+      url:,
+      result:,
+      test_session_id: test_session.id,
+      request_body: body.to_json,
+      status: 200,
+      tags:
+    )
+  end
+
+  def result_messages
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [test])
+      .first
+      .messages
+  end
+
+  it 'skips when no hook requests have been received' do
+    result = run(test)
+    expect(result.result).to eq('skip')
+    expect(result.result_message).to match(/No appointment-book hook requests received/)
+  end
+
+  it 'passes when the request URL and fhirServer both use https' do
+    create_hook_request
+    result = run(test)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'passes when fhirServer is absent' do
+    create_hook_request(fhir_server: nil)
+    result = run(test)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'fails when the request URL uses http' do
+    create_hook_request(url: 'http://example.com/cds-services/appointment-book-service')
+    result = run(test)
+    expect(result.result).to eq('fail')
+    expect(result_messages.map(&:message))
+      .to include(match(/Inferno's simulated CRD Service must use the https protocol/))
+  end
+
+  it 'fails when fhirServer uses http' do
+    create_hook_request(fhir_server: 'http://fhir.example.com')
+    result = run(test)
+    expect(result.result).to eq('fail')
+    expect(result_messages.map(&:message)).to include(match(/fhirServer.*must use the https protocol/))
+  end
+
+  it 'reports the request number when one of multiple requests fails' do
+    create_hook_request
+    create_hook_request(fhir_server: 'http://fhir.example.com')
+    result = run(test)
+    expect(result.result).to eq('fail')
+    expect(result_messages.map(&:message)).to include(match(/\(Request 2\).*fhirServer/))
+  end
+
+  describe 'when a crd_test_group is configured' do
+    let(:test) do
+      Class.new(described_class) do
+        config(options: { hook_name: 'appointment-book', crd_test_group: 'some-group' })
+      end
+    end
+
+    it 'only loads requests tagged with both the hook name and group tag' do
+      create_hook_request(url: 'http://example.com/insecure', tags: ['appointment-book'])
+      create_hook_request(tags: ['appointment-book', 'some-group'])
+      result = run(test)
+      expect(result.result).to eq('pass')
+    end
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/retrieve_jwks_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/retrieve_jwks_test_spec.rb
@@ -1,0 +1,150 @@
+require_relative '../../../lib/davinci_crd_test_kit/client/v2.2.1/auth/retrieve_jwks_test'
+
+RSpec.describe DaVinciCRDTestKit::V221::RetrieveJWKSTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:test) { described_class }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+
+  let(:example_client_url) { 'https://cds.example.org' }
+  let(:example_client_jwks_url) { "#{example_client_url}/jwks.json" }
+  let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
+  let(:jwks_hash) { JSON.parse(DaVinciCRDTestKit::JWKS.jwks_json) }
+  let(:jwk) { jwks_hash['keys'].find { |key| key['alg'] == 'RS384' } }
+  let(:token_header) do
+    {
+      alg: 'RS384',
+      kid: jwk['kid'],
+      typ: 'JWT',
+      jku: example_client_jwks_url
+    }
+  end
+
+  let(:jwks_hash_no_keys) { { keys: [] } }
+  let(:invalid_jwks_hash) do
+    {
+      keys: jwks_hash['keys'].each { |key| key['kid'] = 1234 }
+    }
+  end
+  let(:jwks_hash_dup_kids) do
+    {
+      keys: jwks_hash['keys'].each { |key| key['kid'] = jwk['kid'] }
+    }
+  end
+  let(:jwks_hash_no_kids) { { keys: jwks_hash['keys'].map { |key| key.except('kid') } } }
+
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [test])
+      .first
+      .messages
+      .first
+  end
+
+  it 'passes if it receives a valid JWT Authorization header with jku field populated' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwks_hash.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('pass')
+    expect(jwks_request).to have_been_made
+  end
+
+  it 'passes if it receives multiple valid JWT Authorization headers with jku field populated' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwks_hash.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json, token_header.to_json],
+                       cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('pass')
+    expect(jwks_request).to have_been_made.times(2)
+  end
+
+  it 'fails if it receives at least 1 invalid JWT Authorization headers' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwks_hash.to_json).then
+      .to_return(status: 404, body: jwks_hash.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json, token_header.to_json],
+                       cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(
+      /\(Request 2\) Unexpected response status: expected 200, but received/
+    )
+    expect(jwks_request).to have_been_made.times(2)
+  end
+
+  it 'passes if it receives a valid jwk_set input' do
+    token_header_no_jku = token_header.except(:jku)
+
+    result = run(test, auth_token_headers_json: [token_header_no_jku.to_json], cds_jwk_set: jwks_hash.to_json)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'skips if jku field is not set, and no jwk_set is provided' do
+    token_header_no_jku = token_header.except(:jku)
+
+    result = run(test, auth_token_headers_json: [token_header_no_jku.to_json])
+    expect(result.result).to eq('skip')
+    expect(result.result_message).to match("JWK Set must be inputted if Client's JWK Set is not available")
+  end
+
+  it 'fails if it receives non 200 response' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 404, body: jwks_hash.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/Unexpected response status: expected 200, but received/)
+    expect(jwks_request).to have_been_made
+  end
+
+  it 'fails if jwks returned is not a valid json' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: nil)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/Fetched jku url response contains invalid JSON\./)
+    expect(jwks_request).to have_been_made
+  end
+
+  it 'fails if jwks returned is not an array' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwk.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/JWKS `keys` field must be an array/)
+    expect(jwks_request).to have_been_made
+  end
+
+  it 'fails if jwks returned has no keys' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwks_hash_no_keys.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/The JWK set returned contains no public keys/)
+    expect(jwks_request).to have_been_made
+  end
+
+  it 'fails if jwks returned does not contain kid field' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwks_hash_no_kids.to_json)
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(
+      /`kid` field must be present in each key if JWKS contains multiple keys/
+    )
+    expect(jwks_request).to have_been_made
+  end
+
+  it 'fails if jwks returned contains duplicate kid fields' do
+    jwks_request = stub_request(:get, example_client_jwks_url)
+      .to_return(status: 200, body: jwks_hash_dup_kids.to_json)
+    result = run(test, auth_token_headers_json: [token_header.to_json], cds_jwk_set: example_client_jwks_url)
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/`kid` must be unique within the client's JWK Set\./)
+    expect(jwks_request).to have_been_made
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/token_header_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/token_header_test_spec.rb
@@ -1,0 +1,90 @@
+require_relative '../../../lib/davinci_crd_test_kit/client/v2.2.1/auth/token_header_test'
+
+RSpec.describe DaVinciCRDTestKit::V221::TokenHeaderTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:test) { described_class }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+
+  let(:example_client_url) { 'https://cds.example.org' }
+  let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client" }
+  let(:jwks_hash_keys) { JSON.parse(DaVinciCRDTestKit::JWKS.jwks_json)['keys'] }
+  let(:jwk) { jwks_hash_keys.find { |key| key['alg'] == 'RS384' } }
+
+  let(:token_header) do
+    {
+      alg: 'RS384',
+      kid: jwk['kid'],
+      typ: 'JWT',
+      jku: "#{example_client_url}/jwks.json"
+    }
+  end
+
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [test])
+      .first
+      .messages
+      .first
+  end
+
+  it 'passes if it receives a valid JWT Authorization header' do
+    result = run(test, auth_token_headers_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    expect(result.result).to eq('pass')
+  end
+
+  it 'passes if it receives multiple requests with valid JWT Authorization headers' do
+    result = run(test, auth_token_headers_json: [token_header.to_json, token_header.to_json],
+                       crd_jwks_keys_json: [jwks_hash_keys.to_json, jwks_hash_keys.to_json])
+    expect(result.result).to eq('pass')
+  end
+
+  it 'fails if it receives at least 1 request with invalid JWT Authorization headers' do
+    invalid_token_header = token_header.except(:alg)
+    result = run(test, auth_token_headers_json: [token_header.to_json, invalid_token_header.to_json],
+                       crd_jwks_keys_json: [jwks_hash_keys.to_json, jwks_hash_keys.to_json])
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/\(Request 2\) Token header must have the `alg` field/)
+  end
+
+  it 'fails if it receives a JWT header without the `alg` field' do
+    invalid_token_header = token_header.except(:alg)
+
+    result = run(test, auth_token_headers_json: [invalid_token_header.to_json],
+                       crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/Token header must have the `alg` field/)
+  end
+
+  it 'fails if it receives a JWT header without the `typ` field' do
+    invalid_token_header = token_header.except(:typ)
+
+    result = run(test, auth_token_headers_json: [invalid_token_header.to_json],
+                       crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/Token header must have the `typ` field/)
+  end
+
+  it 'fails if it receives a JWT header with the `typ` field not set to JWT' do
+    token_header[:typ] = 'Bearer'
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/Token header `typ` field must be set to 'JWT', instead was/)
+  end
+
+  it 'fails if it receives a JWT header without the `kid` field' do
+    invalid_token_header = token_header.except(:kid)
+
+    result = run(test, auth_token_headers_json: [invalid_token_header.to_json],
+                       crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/Token header must have the `kid` field/)
+  end
+
+  it 'fails if it receives a JWT header that does not contain a kid found in the jwks' do
+    token_header[:kid] = '12345'
+
+    result = run(test, auth_token_headers_json: [token_header.to_json], crd_jwks_keys_json: [jwks_hash_keys.to_json])
+    expect(result.result).to eq('fail')
+    expect(entity_result_message.message).to match(/JWKS did not contain a public key with an id of `12345`/)
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/token_payload_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/token_payload_test_spec.rb
@@ -1,0 +1,175 @@
+require_relative '../../../lib/davinci_crd_test_kit/client/v2.2.1/auth/token_payload_test'
+require_relative '../../../lib/davinci_crd_test_kit/server/jwt_helper'
+
+RSpec.describe DaVinciCRDTestKit::V221::TokenPayloadTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:jwt_helper) { Class.new(DaVinciCRDTestKit::JwtHelper) }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:runnable) { Inferno::Repositories::Tests.new.find('crd_v221_token_payload') }
+
+  let(:example_client_url) { 'https://cds.example.org' }
+  let(:base_url) { "#{Inferno::Application['base_url']}/custom/crd_client_v221" }
+  let(:appointment_book_url) { "#{base_url}/cds-services/appointment-book-service" }
+
+  let(:jwks_hash) { JSON.parse(DaVinciCRDTestKit::JWKS.jwks_json) }
+  let(:jwk) { jwks_hash['keys'].find { |key| key['alg'] == 'RS384' } }
+
+  let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:rsa_jwk) { JWT::JWK.new(rsa_key) }
+  let(:rsa_jwk_hash) { JSON.parse(rsa_jwk.to_json)['parameters'] }
+
+  let(:token_header) do
+    {
+      alg: 'RS384',
+      kid: rsa_jwk['kid'],
+      typ: 'JWT',
+      jku: "#{example_client_url}/jwks.json"
+    }
+  end
+
+  let(:token_payload) do
+    {
+      aud: appointment_book_url,
+      iss: example_client_url,
+      iat: Time.now.to_i,
+      exp: 5.minutes.from_now.to_i,
+      jti: SecureRandom.hex(32)
+    }
+  end
+
+  def entity_result_message
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
+      .first
+  end
+
+  describe 'CRD Appointment Book Token Payload' do
+    let(:test) do
+      Class.new(DaVinciCRDTestKit::V221::TokenPayloadTest) do
+        config(
+          options: { hook_path: '/cds-services/appointment-book-service' }
+        )
+      end
+    end
+
+    it 'passes if it receives a valid JWT payload' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      result = run(test, auth_tokens: [token], auth_tokens_jwk_json: [jwk.to_json], cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes if it receives multiple valid JWT payloads' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      result = run(test, auth_tokens: [token, token], auth_tokens_jwk_json: [jwk.to_json, jwk.to_json],
+                         cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if it receives at least 1 invalid JWT payload' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      invalid_token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: 'incorrect_iss.com',
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      result = run(test, auth_tokens: [token, invalid_token], auth_tokens_jwk_json: [jwk.to_json, jwk.to_json],
+                         cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/\(Request 2\) Token validation error: Invalid issuer./)
+    end
+
+    it 'fails if it receives a JWT payload with an invalid `iss` field' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: 'incorrect_iss.com',
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      result = run(test, auth_tokens: [token], auth_tokens_jwk_json: [jwk.to_json], cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/Token validation error: Invalid issuer./)
+    end
+
+    it 'fails if it receives a JWT payload with an invalid `aud` field' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: 'incorrect_aud.com',
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      result = run(test, auth_tokens: [token], auth_tokens_jwk_json: [jwk.to_json], cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(
+        'Token validation error: Invalid audience. Expected http://localhost:4567/custom/crd_client_v221/cds-services/appointment-book-service'
+      )
+    end
+
+    it 'fails if it receives a JWT Authorization header with invalid signature' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      token = jwt_helper.build(
+        aud: appointment_book_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      payload, header = jwt_helper.decode_jwt(token, jwks_hash)
+      token_invalid_key = JWT.encode payload, OpenSSL::PKey::RSA.new(2048), 'RS384', header
+
+      result = run(test, auth_tokens: [token_invalid_key], auth_tokens_jwk_json: [jwk.to_json],
+                         cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/Token validation error: Signature verification failed/)
+    end
+
+    it 'fails if it receives a JWT Authorization header with missing claims' do
+      allow(test).to receive(:suite).and_return(suite)
+
+      rsa_jwk_hash['alg'] = 'RS384'
+      invalid_payload = token_payload.except(:exp).except(:exp)
+
+      token_invalid_key = JWT.encode invalid_payload, rsa_key, 'RS384', token_header
+
+      result = run(test,
+                   auth_tokens: [token_invalid_key],
+                   auth_tokens_jwk_json: [rsa_jwk_hash.to_json],
+                   cds_jwt_iss: example_client_url)
+      expect(result.result).to eq('fail')
+      expect(entity_result_message.message).to match(/JWT payload missing required claims: `exp`/)
+    end
+  end
+end


### PR DESCRIPTION
# Summary

A client test added to verify that all communication between the client and service is secured using TLS. In practice, the tests check that hook requests by the client are made to a https endpoint and that the fhirServer that the suite's simulated service will use to request additional FHIR data uses https. The former will always fail when the test kit is run locally without a TLS endpoint setup, and the error message confirms that.

Additional updates and refactors as a part of this PR:
- Created a helper module for loading tagged messages. All v2.2.1 client tests on individual hooks now use it to load requests.
- Created a helper module for handing adding messages to runnables for hook tests that will often evaluate multiple individual requests. The goal is for all messages to have a prefix that indicates the request that triggered them and to indicate in the tests's top-level result message which requests have errors. To work, this approach needs all add_message calls made as a part of evaluating a specific hook request in these multi-request contexts to add the standard prefix. A specific method is provided for test classes to use, but some shared code currently independently encodes the same prefix
  - Standardizes the format for the prefix to messages indicating the request that contains the error (`(Request #)`).
  - Adds a helper method for adding a message with this prefix
  - Adds a helper method for using this prefix to determine which requests have errors associated with them
  - Adds a json parsing helper method that uses this prefix since the standard core one does support prefixes for the added message (only suffixes).
- Added additional spec tests for client v2.2.1 tests copied from v2.0.1
- Refactored existing client v2.2.1 hook tests to use both of the new helper modules.

# Testing Guidance

Test by running the client suite against the server suite

1. start a CRD client v2.2.1 session using the 3.1.1 version of us core
2. apply preset "Run against the CRD Server Suite"
3. Run group 1.2.6 order-sign with no changes to inputs
4. Once a wait dialog appears, create a CRD server v2.2.1 session
5. apply preset "Run against the CRD Client Suite"
6. Run group 1 Discovery
7. When it completes, run group 3.6 order-sign with no changes to inputs
8. When it completes, return to the client session and click the link to continue the tests. Attest to the display of responses when another wait dialog appears to complete the tests.
9. Verify that test 1.2.6.3.08 fails because the tests are running locally without a TLS setup. There will be 3 pairs of errors (6 total), one pair for each request, each with an error for the service url (Inferno's simulated endpoint) and the other for the fhirServer url in the request. Verify that each error has a `(Request #)` prefix and that the test's top-level result message indicates that there are errors on all three requests `(Requests 1, 2, and 3)`.

Additional cases: To check that other tests indicate which request their errors are on, re-run the above process, but with the following changes:
- In step 7, make changes to the hook request bodies in input "Request body or bodies for invoking the `order-sign` hook" that will trigger additional errors on some requests. Make different changes to both the first and the second, such as: changing the resource in a scope, removing a prefetch key, putting a bad status on a resource in the draftOrders context key.
- In step 9, verify additional tests. The first request will be made twice (the first time using the provided request, then a second time with the coverage-info setting turned off), so errors added there will show up twice, while errors in the second request should only show up once. Check both that the request prefix shows up on individual messages and that the top-level error contains the right list of requests with errors.