### PR TITLE
FQM-297 Add service ignore list in case not all CDS services provided are intended to be CRD-conformant

### DIFF
--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -73,6 +73,9 @@ module DaVinciCRDTestKit
             info "Ignoring service `#{service['id']}` because it is in the ignore list."
           end
         services_for_crd_validation = services.reject { |service| ignored_service_ids.include?(service['id']) }
+
+        skip_if services_for_crd_validation.empty?, 'Ignore list excludes all CDS Services from validation.'
+
         service_hooks_to_ids = services_for_crd_validation.each_with_object({}) do |service, hash|
           hash[service['hook']] ||= []
           hash[service['hook']] << service['id'] if service['id']

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -64,7 +64,6 @@ module DaVinciCRDTestKit
 
         services = object['services']
         assert services.is_a?(Array), 'Services field of the CDS Discovery response object is not an array.'
-        skip_if services.empty?, 'Server hosts no CDS Services.'
 
         ignored_service_ids = crd_discovery_service_ignore_list.to_s.split(',').map(&:strip).reject(&:blank?)
         services
@@ -73,8 +72,6 @@ module DaVinciCRDTestKit
             info "Ignoring service `#{service['id']}` because it is in the ignore list."
           end
         services_for_crd_validation = services.reject { |service| ignored_service_ids.include?(service['id']) }
-
-        skip_if services_for_crd_validation.empty?, 'Ignore list excludes all CDS Services from validation.'
 
         service_hooks_to_ids = services_for_crd_validation.each_with_object({}) do |service, hash|
           hash[service['hook']] ||= []
@@ -87,6 +84,9 @@ module DaVinciCRDTestKit
                order_dispatch_service_ids: service_hooks_to_ids['order-dispatch']&.join(', '),
                order_select_service_ids: service_hooks_to_ids['order-select']&.join(', '),
                order_sign_service_ids: service_hooks_to_ids['order-sign']&.join(', ')
+
+        skip_if services.empty?, 'Server hosts no CDS Services.'
+        skip_if services_for_crd_validation.empty?, 'Ignore list excludes all CDS Services from validation.'
 
         services_for_crd_validation.each do |service|
           required_fields.each do |field, type|

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -26,10 +26,24 @@ module DaVinciCRDTestKit
         This test checks for the presence of the required fields and
         validates that they are of the correct type.
 
-        The test will be skipped if the server hosts no CDS services.
+        CDS services provided by the server to support use cases outside the
+        scope of the CRD specification can be provided in an ignore list input to
+        opt-out of CRD validation.
+
+        The test will be skipped if the server hosts no CRD CDS services.
       )
 
       input :cds_services
+      input :crd_discovery_service_ignore_list,
+            title: 'Service ID Ignore List',
+            description: %(
+              In the case that CDS services advertised on this server support
+              use cases outside the scope of the CRD specification, provide a
+              comma-separated list of service IDs to opt-out of CRD validation.
+              Ignored services will not be stored for use in later tests.  If
+              blank, all services are checked and saved.
+            ),
+            optional: true
       output :appointment_book_service_ids, :encounter_start_service_ids, :encounter_discharge_service_ids,
              :order_dispatch_service_ids, :order_select_service_ids, :order_sign_service_ids
 
@@ -52,7 +66,14 @@ module DaVinciCRDTestKit
         assert services.is_a?(Array), 'Services field of the CDS Discovery response object is not an array.'
         skip_if services.empty?, 'Server hosts no CDS Services.'
 
-        service_hooks_to_ids = services.each_with_object({}) do |service, hash|
+        ignored_service_ids = crd_discovery_service_ignore_list.to_s.split(',').map(&:strip).reject(&:blank?)
+        services
+          .select { |service| ignored_service_ids.include?(service['id']) }
+          .each do |service|
+            info "Ignoring service `#{service['id']}` because it is in the ignore list."
+          end
+        services_for_crd_validation = services.reject { |service| ignored_service_ids.include?(service['id']) }
+        service_hooks_to_ids = services_for_crd_validation.each_with_object({}) do |service, hash|
           hash[service['hook']] ||= []
           hash[service['hook']] << service['id'] if service['id']
         end
@@ -64,7 +85,7 @@ module DaVinciCRDTestKit
                order_select_service_ids: service_hooks_to_ids['order-select']&.join(', '),
                order_sign_service_ids: service_hooks_to_ids['order-sign']&.join(', ')
 
-        services.each do |service|
+        services_for_crd_validation.each do |service|
           required_fields.each do |field, type|
             assert(service[field], "Service `#{service['id']}` did not contain required field: `#{field}`")
             assert(service[field].is_a?(type), "Service `#{service['id']}`: field `#{field}` is not of type #{type}")

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
   let(:suite_id) { 'crd_client' }
   let(:runnable) { described_class }
+  let(:results_repo) { Inferno::Repositories::Results.new }
   let(:cds_service) do
     {
       'hook' => 'appointment-book',
@@ -12,6 +13,18 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
         'patient' => 'Patient/{{context.patientId}}'
       }
     }
+  end
+  let(:non_crd_service) do
+    cds_service.merge(
+      'id' => 'non-crd-appointment-book-service',
+      'extension' => nil
+    )
+  end
+
+  def entity_result_messages
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages
   end
 
   it 'succeeds when all services contain a valid davinci-crd.version extension' do
@@ -83,5 +96,48 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
 
     expect(result.result).to eq('fail'), result.result_message
     expect(result.result_message).to match(/invalid version strings/)
+  end
+
+  it 'does not apply CRD-specific discovery requirements to ignored services' do
+    crd_service = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.2'] })
+
+    result = run(
+      runnable,
+      cds_services: { 'services' => [crd_service, non_crd_service] }.to_json,
+      crd_discovery_service_ignore_list: 'non-crd-appointment-book-service'
+    )
+
+    expect(result.result).to eq('pass'), result.result_message
+    expect(session_data_repo.load(test_session_id: test_session.id, name: 'appointment_book_service_ids'))
+      .to eq('appointment-book-service')
+    expect(entity_result_messages.find { |message| message.type == 'info' }&.message)
+      .to match(/Ignoring service `non-crd-appointment-book-service`/)
+  end
+
+  it 'accepts comma separated ignored service ids' do
+    crd_service = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.2'] })
+
+    result = run(
+      runnable,
+      cds_services: { 'services' => [crd_service, non_crd_service] }.to_json,
+      crd_discovery_service_ignore_list: 'other-service, non-crd-appointment-book-service'
+    )
+
+    expect(result.result).to eq('pass'), result.result_message
+    expect(session_data_repo.load(test_session_id: test_session.id, name: 'appointment_book_service_ids'))
+      .to eq('appointment-book-service')
+  end
+
+  it 'does not validate ignored services against CDS Hooks discovery requirements' do
+    crd_service = cds_service.merge('extension' => { 'davinci-crd.version' => ['2.2'] })
+    invalid_service = non_crd_service.merge('description' => nil)
+
+    result = run(
+      runnable,
+      cds_services: { 'services' => [crd_service, invalid_service] }.to_json,
+      crd_discovery_service_ignore_list: 'non-crd-appointment-book-service'
+    )
+
+    expect(result.result).to eq('pass'), result.result_message
   end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
@@ -140,4 +140,15 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
 
     expect(result.result).to eq('pass'), result.result_message
   end
+
+  it 'skips if all discovered services are ignored for CRD validation' do
+    result = run(
+      runnable,
+      cds_services: { 'services' => [non_crd_service] }.to_json,
+      crd_discovery_service_ignore_list: 'non-crd-appointment-book-service'
+    )
+
+    expect(result.result).to eq('skip'), result.result_message
+    expect(result.result_message).to eq('Ignore list excludes all CDS Services from validation.')
+  end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_services_validation_test_spec.rb
@@ -141,7 +141,24 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
     expect(result.result).to eq('pass'), result.result_message
   end
 
+  it 'persists blank service id outputs if no services are discovered' do
+    session_data_repo.save(test_session_id: test_session.id, name: 'appointment_book_service_ids',
+                           value: 'stale-service-id', type: 'text')
+
+    result = run(
+      runnable,
+      cds_services: { 'services' => [] }.to_json
+    )
+
+    expect(result.result).to eq('skip'), result.result_message
+    expect(result.result_message).to eq('Server hosts no CDS Services.')
+    expect(session_data_repo.load(test_session_id: test_session.id, name: 'appointment_book_service_ids')).to be_nil
+  end
+
   it 'skips if all discovered services are ignored for CRD validation' do
+    session_data_repo.save(test_session_id: test_session.id, name: 'appointment_book_service_ids',
+                           value: 'stale-service-id', type: 'text')
+
     result = run(
       runnable,
       cds_services: { 'services' => [non_crd_service] }.to_json,
@@ -150,5 +167,6 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryServicesValidationTest do
 
     expect(result.result).to eq('skip'), result.result_message
     expect(result.result_message).to eq('Ignore list excludes all CDS Services from validation.')
+    expect(session_data_repo.load(test_session_id: test_session.id, name: 'appointment_book_service_ids')).to be_nil
   end
 end


### PR DESCRIPTION
# Summary

In the case that the server provides CDS services that are outside the scope of CRD, the tester can input a comma-separated list of services to ignore.   It ignores them in discovery validation, and then does not persist them for later tests (thus effectively ignoring them for all tests).  This is included so that we do not over-constrain CDS servers in a way that prevents CRD and non-CRD services from being provided in one endpoint.

<img width="593" height="702" alt="Screenshot 2026-05-06 at 2 08 48 PM" src="https://github.com/user-attachments/assets/d91d59be-0796-47d9-b001-e47a153602b7" />

# Testing Guidance

Run the Discover test against the client tests preset.  By default, the discovery test should function the same.  If you add `appointment-book-service` an 'info' message will appear in the log stating that it is being ignored, and the associated hook will be gone from the OUTPUT variable.  There is no way to have the mock server advertise an additional non-CRD service.  I do not think we need to have our simulated server have this level of functionality as it is not mentioned in the spec.

