### PR TITLE
ID-113: fhirpath collections as comma delimited string

### DIFF
--- a/lib/davinci_crd_test_kit/client/endpoints/custom_service_response.rb
+++ b/lib/davinci_crd_test_kit/client/endpoints/custom_service_response.rb
@@ -35,6 +35,14 @@ module DaVinciCRDTestKit
       hook_response['systemActions'] = instantiate_actions(hook_response, 'systemActions')
 
       hook_response
+    rescue FhirpathServiceError => e
+      error_response(
+        'FHIRPath service error while generating custom response. ' \
+        'Check the FHIRPath expressions and data in your response template. ' \
+        "Details: #{e.message}",
+        code: 500
+      )
+      nil
     end
 
     def finalize_card_list(hook_response)

--- a/lib/davinci_crd_test_kit/client/endpoints/custom_service_response.rb
+++ b/lib/davinci_crd_test_kit/client/endpoints/custom_service_response.rb
@@ -38,7 +38,7 @@ module DaVinciCRDTestKit
     rescue FhirpathServiceError => e
       error_response(
         'FHIRPath service error while generating custom response. ' \
-        'Check the FHIRPath expressions and data in your response template. ' \
+        'Check the FHIRPath expressions and data in your response template and hook request. ' \
         "Details: #{e.message}",
         code: 500
       )

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_cross_hook_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_cross_hook_group.rb
@@ -1,5 +1,6 @@
 require_relative 'must_support/client_card_must_support_coverage_information_test'
 require_relative 'must_support/client_location_address_propagation_test'
+require_relative 'must_support/client_fhirpath_collection_as_comma_delimited_string_test'
 
 module DaVinciCRDTestKit
   module V221
@@ -17,6 +18,7 @@ module DaVinciCRDTestKit
 
       test from: :crd_v221_client_card_must_support_coverage_information
       test from: :crd_v221_client_location_address_propagation
+      test from: :crd_v221_client_fhir_path_collection_as_comma_delimited_string
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/must_support/client_fhirpath_collection_as_comma_delimited_string_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/must_support/client_fhirpath_collection_as_comma_delimited_string_test.rb
@@ -1,0 +1,56 @@
+module DaVinciCRDTestKit
+  module V221
+    class ClientFHIRPathCollectionAsCommaDelimitedStringTest < Inferno::Test
+      title 'Prefetch FHIRPath Collection Token Substitution'
+      id :crd_v221_client_fhir_path_collection_as_comma_delimited_string
+      description <<~DESCRIPTION
+        CDS Hooks requires that when a Prefetch FHIRPath token resolves
+        to a collection of datatypes (e.g., resource ids), then the collection
+        gets turned into a comma-delimited string when instantiating the prefetch
+        template.
+
+        This test checks that during a hook test, there was at least one instance
+        of a prefetch template identified that has a token Inferno expects to result
+        in a collection. Note that this does not test whether the client correctly
+        handles the collection, which is checked by the Prefetch Completeness test.
+
+        This test relies on the evaluation performed by the Prefetch Completeness tests
+        present in each hook group. One of these groups must have been run and resulted
+        in a Prefetch Completeness test that outputs
+        "demonstrates_fhirpath_collection_as_comma_delimited_string" as true.
+      DESCRIPTION
+
+      run do
+        completeness_tests = find_completeness_tests
+        pass_if completeness_tests_demonstrate_collection_token_substitution?(completeness_tests)
+
+        skip 'No prefetch template requiring FHIRPath collection token substitution demonstrated. ' \
+             'Perform more complex hook requests and re-run.'
+      end
+
+      def find_completeness_tests
+        hooks_group = self.class.parent.parent.groups.find do |g|
+          g.id.to_s.include?('crd_v221_client_hooks')
+        end
+        hooks_group.groups.map do |group|
+          group.groups.flat_map(&:tests).find do |test|
+            test.id.to_s.include?('crd_v221_hook_request_prefetch_complete')
+          end
+        end.compact
+      end
+
+      def completeness_tests_demonstrate_collection_token_substitution?(prefetch_completeness_tests)
+        results_repo = Inferno::Repositories::Results.new
+        results = results_repo.current_results_for_test_session_and_runnables(test_session_id,
+                                                                              prefetch_completeness_tests)
+
+        results.any? do |result|
+          result.outputs.any? do |output|
+            output['name'] == 'demonstrates_fhirpath_collection_as_comma_delimited_string' &&
+              output['value'] == 'true'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_complete_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_complete_test.rb
@@ -27,20 +27,32 @@ module DaVinciCRDTestKit
       )
       # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@54', 'cds-hooks_2.0@30', 'cds-hooks_2.0@47'
 
+      # output emitted only if the behavior is detected
+      output :demonstrates_fhirpath_collection_as_comma_delimited_string
+
       run do
         hook_requests = load_hook_requests
 
         skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
+
+        collection_as_comma_delimited_string_demonstrated = false
 
         hook_requests.each_with_index do |request, request_index|
           hook_request = parse_json_request_entity(request.request_body, 'Request body', request_index)
           next unless hook_request.present?
 
           services_path = File.join(__dir__, '..', 'cds-services-v221.json')
-          PrefetchCompletenessChecker.new(hook_request, request_index,
-                                          services_path).check_prefetched_data.each do |error|
+          checker = PrefetchCompletenessChecker.new(hook_request, request_index, services_path)
+          checker.check_prefetched_data.each do |error|
             add_message('error', error) # NOTE: PrefetchCompletenessChecker adds the (Request #) prefix
           end
+          if checker.observed_fhirpath_collection_as_comma_delimited_string
+            collection_as_comma_delimited_string_demonstrated = true
+          end
+        end
+
+        if collection_as_comma_delimited_string_demonstrated
+          output demonstrates_fhirpath_collection_as_comma_delimited_string: true
         end
 
         assert_no_error_messages("#{requests_with_errors_prefix}Incomplete or invalid prefetched data. " \

--- a/lib/davinci_crd_test_kit/cross_suite/fhirpath_on_cds_request.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/fhirpath_on_cds_request.rb
@@ -88,6 +88,7 @@ module DaVinciCRDTestKit
 
     def delegate_execution_to_fhirpath_engine(hash, fhirpath_query)
       return [hash] unless fhirpath_query.present?
+      return [] unless hash.present?
 
       result = fhirpath_evaluator.call_fhirpath_service(hash, fhirpath_query)
       unless result.status.to_s.starts_with?('2')

--- a/lib/davinci_crd_test_kit/cross_suite/fhirpath_on_cds_request.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/fhirpath_on_cds_request.rb
@@ -1,4 +1,6 @@
 module DaVinciCRDTestKit
+  class FhirpathServiceError < StandardError; end
+
   # Methods for executing simple fhirpath queries on cds request objects, e.g., to resolve
   # prefetch tokens.
   #
@@ -92,9 +94,10 @@ module DaVinciCRDTestKit
 
       result = fhirpath_evaluator.call_fhirpath_service(hash, fhirpath_query)
       unless result.status.to_s.starts_with?('2')
-        puts "Error on fhirpath #{fhirpath_query} on #{hash.to_json}: #{result.body}"
+        raise FhirpathServiceError,
+              "FHIRPath service returned #{result.status} for query '#{fhirpath_query}' " \
+              "on resource #{hash.to_json}: #{result.body}"
       end
-      return [] unless result.status.to_s.starts_with?('2')
 
       JSON.parse(result.body).map { |entry| entry['element'] }
     end

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
@@ -24,17 +24,7 @@ module DaVinciCRDTestKit
       return ["#{request_error_prefix} No prefetch data provided."] unless hook_request.key?('prefetch')
 
       hook_prefetch_templates.each do |prefetch_key, prefetch_request|
-        @current_prefetch_key = prefetch_key
-        original_prefetch_request = prefetch_request.dup
-        instantiated_request = replace_tokens_in_string(prefetch_request, hook_request)
-        if demonstrates_collection_as_comma_delimited_string?(original_prefetch_request, instantiated_request)
-          @observed_fhirpath_collection_as_comma_delimited_string = true
-        end
-        unless hook_request['prefetch'].key?(prefetch_key)
-          errors << "#{error_prefix} No prefetch data provided."
-          next
-        end
-        check_provided_against_request(hook_request['prefetch'][prefetch_key], instantiated_request)
+        check_prefetch_template(prefetch_key, prefetch_request)
       end
 
       hook_request['prefetch'].each_key do |prefetch_template|
@@ -77,6 +67,22 @@ module DaVinciCRDTestKit
     # -----------------------------------------------------------------------
     # Check of actual prefetch against an instantiated request
     # -----------------------------------------------------------------------
+    def check_prefetch_template(prefetch_key, prefetch_request)
+      @current_prefetch_key = prefetch_key
+      instantiated_request = replace_tokens_in_string(prefetch_request.dup, hook_request)
+      if demonstrates_collection_as_comma_delimited_string?(prefetch_request, instantiated_request)
+        @observed_fhirpath_collection_as_comma_delimited_string = true
+      end
+      unless hook_request['prefetch'].key?(prefetch_key)
+        errors << "#{error_prefix} No prefetch data provided."
+        return
+      end
+      check_provided_against_request(hook_request['prefetch'][prefetch_key], instantiated_request)
+    rescue FhirpathServiceError => e
+      raise "#{error_prefix} FHIRPath service error while evaluating prefetch template. " \
+            "This indicates an implementation problem in Inferno. Details: #{e.message}"
+    end
+
     def check_provided_against_request(prefetched_value, instantiated_request)
       if instantiated_request.include?('?')
         if id_search?(instantiated_request)

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
@@ -80,7 +80,7 @@ module DaVinciCRDTestKit
       check_provided_against_request(hook_request['prefetch'][prefetch_key], instantiated_request)
     rescue FhirpathServiceError => e
       raise "#{error_prefix} FHIRPath service error while evaluating prefetch template. " \
-            "This indicates an implementation problem in Inferno. Details: #{e.message}"
+            "This indicates an implementation problem in Inferno - please log a ticket. Details: #{e.message}"
     end
 
     def check_provided_against_request(prefetched_value, instantiated_request)

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
@@ -9,12 +9,14 @@ module DaVinciCRDTestKit
     include FhirpathOnCDSRequest
     include ReplaceTokens
 
-    attr_accessor :hook_request, :request_index, :services_file_path
+    attr_accessor :hook_request, :request_index, :services_file_path,
+                  :observed_fhirpath_collection_as_comma_delimited_string
 
     def initialize(hook_request, request_index, services_file_path)
       @hook_request = hook_request
       @request_index = request_index
       @services_file_path = services_file_path
+      @observed_fhirpath_collection_as_comma_delimited_string = false
       extract_prefetched_resources
     end
 
@@ -23,7 +25,11 @@ module DaVinciCRDTestKit
 
       hook_prefetch_templates.each do |prefetch_key, prefetch_request|
         @current_prefetch_key = prefetch_key
+        original_prefetch_request = prefetch_request.dup
         instantiated_request = replace_tokens_in_string(prefetch_request, hook_request)
+        if demonstrates_collection_as_comma_delimited_string?(original_prefetch_request, instantiated_request)
+          @observed_fhirpath_collection_as_comma_delimited_string = true
+        end
         unless hook_request['prefetch'].key?(prefetch_key)
           errors << "#{error_prefix} No prefetch data provided."
           next
@@ -279,6 +285,20 @@ module DaVinciCRDTestKit
                 'was not provided in the prefetched values.'
 
       nil
+    end
+
+    # -------------------------------------------------------------------------
+    # Observe a Collection represented as a comma-delimited string in instantiated search
+    # -------------------------------------------------------------------------
+
+    # client will have demonstrated turning a collection into a comma-delimited string if both
+    # - the prefetch request follows the RESOURCE?_id={{TOKEN}} form when TOKEN has a | indicating 'and', and
+    # - the instantiated query actually has multiple unique ids
+    def demonstrates_collection_as_comma_delimited_string?(prefetch_request, instantiated_request)
+      token = prefetch_request.match(/[a-zA-Z]*\?_id=\{\{(.+?)\}\}/)&.[](1)
+      return false unless token.present? && token.include?('|')
+
+      instantiated_request.split('?_id=').last.split(',').uniq.size > 1
     end
   end
 end

--- a/spec/davinci_crd_test_kit/custom_service_response_spec.rb
+++ b/spec/davinci_crd_test_kit/custom_service_response_spec.rb
@@ -195,6 +195,52 @@ RSpec.describe DaVinciCRDTestKit::CustomServiceResponse, :request do
         .to_return(status: 200, body: crd_coverage_bundle.to_json)
     end
 
+    it 'returns a 500 error when the FHIRPath service fails during inclusion criteria evaluation' do
+      allow(test).to receive(:suite).and_return(suite)
+      stub_request(:post, /#{Regexp.escape(fhirpath_url)}/)
+        .to_return(status: 422, body: 'Invalid FHIRPath expression')
+
+      token = jwt_helper.build(
+        aud: order_sign_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+      instructions_card_template['extension'] =
+        { 'com.inferno.inclusionCriteria': 'context.draftOrders.entry.resource.ofType(MedicationRequest).exists()' }
+      response_template = { cards: [instructions_card_template] }
+      run(test, cds_jwt_iss: example_client_url, order_sign_custom_response_template: response_template.to_json)
+
+      header('Authorization', "Bearer #{token}")
+      post_json(server_endpoint, body)
+
+      expect(last_response).to be_server_error
+      expect(last_response.body).to match(/FHIRPath service error while generating custom response/)
+    end
+
+    it 'returns a 500 error when the FHIRPath service fails during resource selection criteria evaluation' do
+      allow(test).to receive(:suite).and_return(suite)
+      stub_request(:post, /#{Regexp.escape(fhirpath_url)}/)
+        .to_return(status: 422, body: 'Invalid FHIRPath expression')
+
+      token = jwt_helper.build(
+        aud: order_sign_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+      system_action_template_delete_with_tokens['extension'] =
+        { 'com.inferno.resourceSelectionCriteria': 'context.draftOrders.entry.resource.ofType(MedicationRequest)' }
+      response_template = { cards: [], systemActions: [system_action_template_delete_with_tokens] }
+      run(test, cds_jwt_iss: example_client_url, order_sign_custom_response_template: response_template.to_json)
+
+      header('Authorization', "Bearer #{token}")
+      post_json(server_endpoint, body)
+
+      expect(last_response).to be_server_error
+      expect(last_response.body).to match(/FHIRPath service error while generating custom response/)
+    end
+
     it 'returns 400 when bad json specified in the input' do
       allow(test).to receive(:suite).and_return(suite)
 

--- a/spec/davinci_crd_test_kit/fhirpath_on_cds_request_spec.rb
+++ b/spec/davinci_crd_test_kit/fhirpath_on_cds_request_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe DaVinciCRDTestKit::FhirpathOnCDSRequest do
   end
 
   describe 'for fhirpath on resources in the cds object' do
+    it 'returns an empty array without calling the fhirpath service when the target hash is nil' do
+      stub_request(:post, /#{Regexp.escape(fhirpath_url)}/)
+      results = module_instance.execute_fhirpath_on_cds_request(
+        order_sign_request,
+        'context.nonExistentField.someProperty'
+      )
+      expect(results).to eq([])
+      expect(a_request(:post, /#{Regexp.escape(fhirpath_url)}/)).not_to have_been_made
+    end
+
     it 'returns the value for a nested FHIR resource field' do
       fhirpath_result = [{ type: 'id', element: 'pureeddiet-simple' },
                          { type: 'id', element: 'smart-MedicationRequest-103' }]

--- a/spec/davinci_crd_test_kit/fhirpath_on_cds_request_spec.rb
+++ b/spec/davinci_crd_test_kit/fhirpath_on_cds_request_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe DaVinciCRDTestKit::FhirpathOnCDSRequest do
         'context.nonExistentField.someProperty'
       )
       expect(results).to eq([])
-      expect(a_request(:post, /#{Regexp.escape(fhirpath_url)}/)).not_to have_been_made
+      expect(a_request(:post, /#{Regexp.escape(fhirpath_url)}/)).to_not have_been_made
     end
 
     it 'returns the value for a nested FHIR resource field' do

--- a/spec/davinci_crd_test_kit/prefetch_completeness_checker_spec.rb
+++ b/spec/davinci_crd_test_kit/prefetch_completeness_checker_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe DaVinciCRDTestKit::PrefetchCompletenessChecker do
       errors = errors_for(order_sign_request, { 'patient' => 'Patient/{{context.patientId}}' })
       expect(errors).to eq(["(Request 1) Extra prefetch data provided in unrequested template 'extra'."])
     end
+
+    it 'raises an error with template context when the FHIRPath service fails during token substitution' do
+      templates = { 'orders' => 'ServiceRequest?_id={{context.draftOrders.entry.resource.id}}' }
+      order_sign_request['prefetch'] = { 'orders' => { 'resourceType' => 'Bundle', 'entry' => [] } }
+      stub_request(:post, /#{Regexp.escape(fhirpath_url)}/)
+        .to_return(status: 422, body: 'Invalid FHIRPath expression')
+
+      checker = make_checker(order_sign_request, templates)
+      expect { checker.check_prefetched_data }
+        .to raise_error(RuntimeError, /Prefetch Template orders.*FHIRPath service error/)
+    end
   end
 
   describe 'read template' do

--- a/spec/davinci_crd_test_kit/prefetch_completeness_checker_spec.rb
+++ b/spec/davinci_crd_test_kit/prefetch_completeness_checker_spec.rb
@@ -312,6 +312,79 @@ RSpec.describe DaVinciCRDTestKit::PrefetchCompletenessChecker do
     end
   end
 
+  describe '#observed_fhirpath_collection_as_comma_delimited_string' do
+    it 'is false by default before check_prefetched_data is called' do
+      checker = make_checker(order_sign_request, {})
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(false)
+    end
+
+    it 'remains false when no _id search template is present' do
+      order_sign_request['prefetch'] = { 'patient' => crd_patient_example }
+      checker = make_checker(order_sign_request, { 'patient' => 'Patient/{{context.patientId}}' })
+      checker.check_prefetched_data
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(false)
+    end
+
+    it 'remains false when the _id template token has no pipe' do
+      order_sign_request['prefetch'] = { 'patient' => crd_patient_example_bundle }
+      checker = make_checker(order_sign_request, { 'patient' => 'Patient?_id={{context.patientId}}' })
+      checker.check_prefetched_data
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(false)
+    end
+
+    it 'remains false when the token has a pipe but only one id is resolved' do
+      order_sign_request['prefetch'] = { 'patient' => crd_patient_example_bundle }
+      checker = make_checker(order_sign_request,
+                             { 'patient' => 'Patient?_id={{context.patientId|context.nonExistentField}}' })
+      checker.check_prefetched_data
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(false)
+    end
+
+    it 'remains false when the token has a pipe and multiple ids resolve but are all the same' do
+      order_sign_request['context']['duplicatePatientId'] = 'example'
+      order_sign_request['prefetch'] = { 'patient' => crd_patient_example_bundle }
+      checker = make_checker(order_sign_request,
+                             { 'patient' => 'Patient?_id={{context.patientId|context.duplicatePatientId}}' })
+      checker.check_prefetched_data
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(false)
+    end
+
+    it 'becomes true when the token has a pipe and multiple ids are resolved' do
+      order_sign_request['context']['secondPatientId'] = 'other'
+      order_sign_request['prefetch'] = { 'patient' => {
+        'resourceType' => 'Bundle',
+        'entry' => [
+          { 'resource' => crd_patient_example },
+          { 'resource' => crd_patient_example.merge('id' => 'other') }
+        ]
+      } }
+      checker = make_checker(order_sign_request,
+                             { 'patient' => 'Patient?_id={{context.patientId|context.secondPatientId}}' })
+      checker.check_prefetched_data
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(true)
+    end
+
+    it 'becomes true when any one of multiple templates demonstrates multi-id collection' do
+      order_sign_request['context']['secondPatientId'] = 'other'
+      order_sign_request['prefetch'] = {
+        'patient' => crd_patient_example,
+        'patients' => {
+          'resourceType' => 'Bundle',
+          'entry' => [
+            { 'resource' => crd_patient_example },
+            { 'resource' => crd_patient_example.merge('id' => 'other') }
+          ]
+        }
+      }
+      checker = make_checker(order_sign_request, {
+                               'patient' => 'Patient/{{context.patientId}}',
+                               'patients' => 'Patient?_id={{context.patientId|context.secondPatientId}}'
+                             })
+      checker.check_prefetched_data
+      expect(checker.observed_fhirpath_collection_as_comma_delimited_string).to be(true)
+    end
+  end
+
   describe 'chained prefetch tokens' do
     let(:templates) do
       {

--- a/spec/davinci_crd_test_kit/v2.2.1/client_fhirpath_collection_as_comma_delimited_string_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/client_fhirpath_collection_as_comma_delimited_string_test_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe DaVinciCRDTestKit::V221::ClientFHIRPathCollectionAsCommaDelimitedStringTest do
+  let(:suite_id) { 'crd_client_v221' }
+
+  let(:runnable) do
+    Inferno::Repositories::Tests.new.find(
+      'crd_client_v221-crd_v221_client_hook_invocation-crd_v221_client_cross_hook' \
+      '-crd_v221_client_fhir_path_collection_as_comma_delimited_string'
+    )
+  end
+
+  let(:prefetch_complete_test) do
+    Inferno::Repositories::Tests.new.find(
+      'crd_client_v221-crd_v221_client_hook_invocation-crd_v221_client_hooks' \
+      '-crd_v221_client_order_sign-Group03-crd_v221_hook_request_prefetch_complete'
+    )
+  end
+
+  def create_prefetch_complete_result(output_json: '[]', result: 'pass')
+    repo_create(
+      :result,
+      test_session_id: test_session.id,
+      runnable: prefetch_complete_test.reference_hash,
+      output_json:,
+      result:
+    )
+  end
+
+  it 'skips when no prefetch completeness test results exist' do
+    expect(run(runnable).result).to eq('skip')
+  end
+
+  it 'skips when completeness results have no collection behavior output' do
+    create_prefetch_complete_result(output_json: '[]')
+    expect(run(runnable).result).to eq('skip')
+  end
+
+  it 'skips when the collection output is present but false' do
+    create_prefetch_complete_result(
+      output_json: [{ name: 'demonstrates_fhirpath_collection_as_comma_delimited_string',
+                      value: 'false' }].to_json
+    )
+    expect(run(runnable).result).to eq('skip')
+  end
+
+  it 'passes when a completeness result demonstrates collection behavior' do
+    create_prefetch_complete_result(
+      output_json: [{ name: 'demonstrates_fhirpath_collection_as_comma_delimited_string',
+                      value: 'true' }].to_json
+    )
+    expect(run(runnable).result).to eq('pass')
+  end
+
+  it 'passes when any one of multiple completeness results demonstrates collection behavior' do
+    create_prefetch_complete_result(output_json: '[]')
+    create_prefetch_complete_result(
+      output_json: [{ name: 'demonstrates_fhirpath_collection_as_comma_delimited_string',
+                      value: 'true' }].to_json
+    )
+    expect(run(runnable).result).to eq('pass')
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_prefetch_complete_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_prefetch_complete_test_spec.rb
@@ -67,4 +67,62 @@ RSpec.describe DaVinciCRDTestKit::V221::HookRequestPrefetchCompleteTest do
     expect(results.result).to eq('fail')
     expect(entity_result_message(test)).to include('(Request 2)')
   end
+
+  describe 'demonstrates_fhirpath_collection_as_comma_delimited_string output' do
+    let(:id_search_template) { { 'patient' => 'Patient?_id={{context.patientId|context.secondPatientId}}' } }
+    let(:crd_patient_example_bundle) do
+      { 'resourceType' => 'Bundle', 'entry' => [{ 'resource' => crd_patient_example }] }
+    end
+
+    it 'does not set the output when no request demonstrates collection behavior' do
+      order_sign_request['prefetch'] = { 'patient' => crd_patient_example }
+      store_hook_request('order-sign', body: order_sign_request)
+      result = run(test)
+      expect(result.result).to eq('pass')
+      output = result.outputs.find { |o| o['name'] == 'demonstrates_fhirpath_collection_as_comma_delimited_string' }
+      expect(output&.dig('value')).to be_blank
+    end
+
+    it 'sets the output to true when a request demonstrates collection behavior' do
+      allow_any_instance_of(DaVinciCRDTestKit::PrefetchCompletenessChecker)
+        .to receive(:hook_prefetch_templates).and_return(id_search_template)
+      order_sign_request['context']['secondPatientId'] = 'other'
+      order_sign_request['prefetch'] = { 'patient' => {
+        'resourceType' => 'Bundle',
+        'entry' => [
+          { 'resource' => crd_patient_example },
+          { 'resource' => crd_patient_example.merge('id' => 'other') }
+        ]
+      } }
+      store_hook_request('order-sign', body: order_sign_request)
+      result = run(test)
+      expect(result.result).to eq('pass')
+      output = result.outputs.find { |o| o['name'] == 'demonstrates_fhirpath_collection_as_comma_delimited_string' }
+      expect(output['value']).to eq('true')
+    end
+
+    it 'sets the output to true when any one of multiple requests demonstrates collection behavior' do
+      allow_any_instance_of(DaVinciCRDTestKit::PrefetchCompletenessChecker)
+        .to receive(:hook_prefetch_templates) { { 'patient' => 'Patient?_id={{context.patientId|context.secondPatientId}}' } }
+
+      order_sign_request['prefetch'] = { 'patient' => crd_patient_example_bundle }
+      store_hook_request('order-sign', body: order_sign_request)
+
+      second_request = JSON.parse(order_sign_request.to_json)
+      second_request['context']['secondPatientId'] = 'other'
+      second_request['prefetch'] = { 'patient' => {
+        'resourceType' => 'Bundle',
+        'entry' => [
+          { 'resource' => crd_patient_example },
+          { 'resource' => crd_patient_example.merge('id' => 'other') }
+        ]
+      } }
+      store_hook_request('order-sign', body: second_request)
+
+      result = run(test)
+      expect(result.result).to eq('pass')
+      output = result.outputs.find { |o| o['name'] == 'demonstrates_fhirpath_collection_as_comma_delimited_string' }
+      expect(output['value']).to eq('true')
+    end
+  end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_prefetch_complete_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_prefetch_complete_test_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe DaVinciCRDTestKit::V221::HookRequestPrefetchCompleteTest do
 
     it 'sets the output to true when any one of multiple requests demonstrates collection behavior' do
       allow_any_instance_of(DaVinciCRDTestKit::PrefetchCompletenessChecker)
-        .to receive(:hook_prefetch_templates) { { 'patient' => 'Patient?_id={{context.patientId|context.secondPatientId}}' } }
+        .to receive(:hook_prefetch_templates)
+        .and_return({ 'patient' => 'Patient?_id={{context.patientId|context.secondPatientId}}' })
 
       order_sign_request['prefetch'] = { 'patient' => crd_patient_example_bundle }
       store_hook_request('order-sign', body: order_sign_request)


### PR DESCRIPTION
# Summary

CDS Hooks requires that when a Prefetch FHIRPath token resolves to a collection of datatypes (e.g., resource ids), then the collection gets turned into a comma-delimited string when instantiating the prefetch template. This PR adds a test that checks that a scenario where a collection with multiple unique entries got turned into a comma-delimited list was demonstrated during the tests, meaning that when gathering prefetch data, clients would have needed to handle this case.

The implementation uses the prefetch completeness checker which is already doing a deep analysis of the prefetch to identify when the data in a request should result in a fhirpath prefetch token evaluating to a collection with multiple unique entries. Then a cross-hook test checks that such a case was observed across all hook tests.

This PR also adds explicit handling of errors coming back from the fhirpath service that were previously silently ignored. Now if a FHIRPath error occurs
- When generating responses, Inferno will return an error response with details instead of a valid CDS Hooks response. The error indicates that the data and fhirpath provided to generate a response was invalid.
- When evaluating prefetched data in the prefetch completeness test, Inferno will raise a purple error with specific details on the issue and ask testers to log a ticket.

# Testing Guidance

Validate by running the client suite against the server suite. The fhirpath error case has no known ways to trigger (happens in unexpected cases), so can only be tested currently via a code change.

## Failing example 

The presets as-is do not demonstrate a multi-entry collection with more than 1 unique entry, so an execution using them will fail (via a skip)

Run with no changes to inputs
1. start a CRD client v2.2.1 session using any version of us core
2. apply preset "Run against the CRD Server Suite"
3. Run group 1.2.6 order-sign with no changes to inputs
4. Once a wait dialog appears, create a CRD server v2.2.1 session
5. apply preset "Run against the CRD Client Suite"
6. Run server group 1 Discovery
7. When it completes, run server group 3.6 order-sign with no changes to inputs
8. When it completes, return to the client session and click the link to continue the tests. Attest to the display of responses when another wait dialog appears to complete the tests.
9. Run client group 1.3 Cross Hook Verification
10. Verify that test 1.3.03 skips
11. Verify that test 1.2.6.3.04 has no outputs

## Passing example

Run the above procedure with the following changes (note: you can re-use the same test sessions and only perform steps 3, and 7-11):
- In step 7, replace input "Request body or bodies for invoking the `order-sign` hook" with the hook request below which references 2 practitioners in the draftOrders DeviceRequest and includes both in the `practitioners` prefetch.
- in step 10, test 1.3.03 will now pass.
- in step 11, test 1.2.6.3.04 will now have output `demonstrates_fhirpath_collection_as_comma_delimited_string` = `true`.

### Hook Request

```
{
  "hookInstance": "d1577c69-dfbe-77ad-ba6d-3e05e953b2ea",
  "fhirServer": "https://inferno.healthit.gov/reference-server/r4",
  "hook": "order-sign",
  "fhirAuthorization": {
    "access_token": "SAMPLE_TOKEN",
    "token_type": "Bearer",
    "expires_in": 300,
    "scope": "user/AllergyIntolerance.rs user/CarePlan.rs user/CareTeam.rs user/Condition.rs user/Device.rs user/DiagnosticReport.rs user/DocumentReference.rs user/Encounter.rs user/Goal.rs user/Immunization.rs user/Location.rs user/Medication.rs user/MedicationRequest.rs user/Observation.rs user/Organization.rs user/Patient.rs user/Practitioner.rs user/PractitionerRole.rs user/Procedure.rs user/Provenance.rs",
    "subject": "cds-service4"
  },
  "context": {
    "userId": "Practitioner/pra1234",
    "patientId": "pat015",
    "encounterId": "pat015-rad-encounter",
    "draftOrders": {
      "resourceType": "Bundle",
      "type": "collection",
      "entry": [
        {
          "fullUrl": "urn:uuid:3aa170b9-48ce-4446-88f6-fb08870e8d4d",
          "resource": {
            "resourceType": "DeviceRequest",
            "id": "devreq-015-e0250",
            "identifier": [
              {
                "type": {
                  "coding": [
                    {
                      "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
                      "code": "PLAC"
                    }
                  ]
                },
                "value": "f105372f-bbef-442c-ad7a-708fee7f8c93"
              }
            ],
            "status": "draft",
            "intent": "original-order",
            "codeCodeableConcept": {
              "coding": [
                {
                  "system": "https://bluebutton.cms.gov/resources/codesystem/hcpcs",
                  "code": "E0250",
                  "display": "Hospital bed fixed height with any type of side rails, mattress"
                }
              ]
            },
            "subject": {
              "reference": "Patient/pat015"
            },
            "authoredOn": "2023-01-01T00:00:00Z",
            "requester": {
              "reference": "Practitioner/pra1234"
            },
            "performer": {
              "reference": "Practitioner/pra1235"
            },
            "insurance": [
              {
                "reference": "Coverage/cov015"
              }
            ]
          }
        }
      ]
    }
  },
  "extension": {
    "davinci-crd.configuration": {
      "alt-drug": true
    },
    "davinci-crd.requestedVersion": "2.2"
  },
  "prefetch": {
    "patient": {
      "resourceType": "Patient",
      "id": "pat015",
      "gender": "male",
      "birthDate": "2015-02-23",
      "address": [
        {
          "use": "home",
          "type": "both",
          "state": "NY",
          "city": "Buffalo",
          "postalCode": "14210",
          "line": [
            "202 Burlington Road"
          ]
        }
      ],
      "name": [
        {
          "use": "official",
          "family": "Oster",
          "given": [
            "William",
            "Hale",
            "Oster"
          ]
        }
      ],
      "telecom": [
        {
          "system": "phone",
          "value": "(781) 555-5555",
          "use": "home",
          "rank": 1
        },
        {
          "system": "phone",
          "value": "(781) 555 5613",
          "use": "work",
          "rank": 2
        },
        {
          "system": "phone",
          "value": "(781) 555 8834",
          "use": "old",
          "period": {
            "end": "2014"
          }
        }
      ],
      "identifier": [
        {
          "use": "usual",
          "type": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
                "code": "MR"
              }
            ],
            "text": "Medical Record Number"
          },
          "system": "http://hl7.org/fhir/sid/us-medicare",
          "value": "0M34355006FW"
        }
      ]
    },
    "encounter": {
      "resourceType": "Encounter",
      "id": "pat015-rad-encounter",
      "status": "finished",
      "class": {
        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
        "code": "HH",
        "display": "home health"
      },
      "type": [
        {
          "coding": [
            {
              "system": "http://snomed.info/sct",
              "code": "185345009",
              "display": "Encounter for symptom"
            }
          ]
        }
      ],
      "priority": {
        "coding": [
          {
            "system": "http://snomed.info/sct",
            "code": "709122007",
            "display": "As soon as possible (qualifier value)"
          }
        ]
      },
      "subject": {
        "reference": "Patient/pat015",
        "display": "Roosevelt Theodore"
      },
      "participant": [
        {
          "individual": {
            "reference": "Practitioner/pra1234",
            "display": "Dr. Jane Doe"
          },
          "type": [
            {
              "coding": [
                {
                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
                  "code": "PPRF",
                  "display": "primary performer"
                }
              ]
            }
          ]
        }
      ],
      "length": {
        "value": 56,
        "unit": "minutes",
        "system": "http://unitsofmeasure.org",
        "code": "min"
      },
      "period": {
        "start": "2020-07-01T10:40:10+01:00",
        "end": "2020-07-01T12:40:10+01:00"
      },
      "reasonCode": [
        {
          "coding": [
            {
              "system": "http://hl7.org/fhir/sid/icd-10-cm",
              "code": "J44.9",
              "display": "Chronic obstructive pulmonary disease, unspecified"
            }
          ]
        }
      ],
      "diagnosis": [
        {
          "condition": {
            "reference": "Condition/cond015a",
            "display": "The patient is hospitalized for stroke"
          },
          "use": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
                "code": "AD",
                "display": "Admission diagnosis"
              }
            ]
          },
          "rank": 2
        },
        {
          "condition": {
            "reference": "Condition/cond015a",
            "display": "The patient is hospitalized for lung condition"
          },
          "use": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
                "code": "CC",
                "display": "Chief complaint"
              }
            ]
          },
          "rank": 1
        }
      ],
      "location": [
        {
          "location": {
            "display": "observation2c"
          }
        }
      ]
    },
    "coverage": {
      "resourceType": "Bundle",
      "type": "searchset",
      "total": 1,
      "link": [
        {
          "relation": "self",
          "url": "https://inferno.healthit.gov/reference-server/r4/Coverage?patient=pat015"
        }
      ],
      "entry": [
        {
          "fullUrl": "https://inferno.healthit.gov/reference-server/r4/Coverage/cov015",
          "resource": {
            "resourceType": "Coverage",
            "id": "cov015",
            "subscriberId": "10A3D58WH456",
            "relationship": {
              "coding": [
                {
                  "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
                  "code": "self"
                }
              ]
            },
            "beneficiary": {
              "reference": "Patient/pat015"
            },
            "status": "active",
            "class": [
              {
                "type": {
                  "coding": [
                    {
                      "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
                      "code": "plan"
                    }
                  ]
                },
                "value": "Medicare Part A"
              }
            ],
            "payor": [
              {
                "reference": "Organization/org1234"
              }
            ]
          },
          "search": {
            "mode": "match"
          }
        }
      ]
    },
    "devices": null,
    "medications": null,
    "practitionerRoles": null,
    "organizations": null,
    "practitioners": {
      "resourceType": "Bundle",
      "type": "collection",
      "entry": [
        {
          "fullUrl": "urn:uuid:3aa170b9-48ce-4446-88f6-fb08870e8d3d",
          "resource": {
            "resourceType": "Practitioner",
            "id": "pra1234",
            "meta": {
              "profile": [
                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
              ]
            },
            "identifier": [
              {
                "system": "http://hl7.org/fhir/sid/us-npi",
                "value": "1122334455"
              }
            ],
            "address": [
              {
                "use": "home",
                "type": "both",
                "state": "NY",
                "city": "Buffalo",
                "postalCode": "14210",
                "line": [
                  "840 Seneca St"
                ]
              }
            ],
            "telecom": [
              {
                "system": "phone",
                "value": "716-873-1557"
              },
              {
                "system": "email",
                "value": "jane.betty@myhospital.com"
              }
            ],
            "name": [
              {
                "use": "official",
                "family": "Doe",
                "given": [
                  "Jane",
                  "Betty"
                ],
                "prefix": [
                  "Dr."
                ]
              }
            ],
            "qualification": [
              {
                "code": {
                  "coding": [
                    {
                      "system": "http://terminology.hl7.org/CodeSystem/v2-0360",
                      "code": "MD",
                      "display": "Doctor of Medicine"
                    }
                  ],
                  "text": "Doctor of Medicine"
                },
                "period": {
                  "start": "1995"
                },
                "issuer": {
                  "display": "Example University"
                }
              }
            ]
          }
        },
        {
          "fullUrl": "urn:uuid:3aa170b9-48ce-4446-88f6-fb08870e8d3d",
          "resource": {
            "resourceType": "Practitioner",
            "id": "pra1235",
            "meta": {
              "profile": [
                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
              ]
            },
            "identifier": [
              {
                "system": "http://hl7.org/fhir/sid/us-npi",
                "value": "1122334455"
              }
            ],
            "address": [
              {
                "use": "home",
                "type": "both",
                "state": "NY",
                "city": "Buffalo",
                "postalCode": "14210",
                "line": [
                  "840 Seneca St"
                ]
              }
            ],
            "telecom": [
              {
                "system": "phone",
                "value": "716-873-1557"
              },
              {
                "system": "email",
                "value": "jane.betty@myhospital.com"
              }
            ],
            "name": [
              {
                "use": "official",
                "family": "Doe",
                "given": [
                  "Jane",
                  "Betty"
                ],
                "prefix": [
                  "Dr."
                ]
              }
            ],
            "qualification": [
              {
                "code": {
                  "coding": [
                    {
                      "system": "http://terminology.hl7.org/CodeSystem/v2-0360",
                      "code": "MD",
                      "display": "Doctor of Medicine"
                    }
                  ],
                  "text": "Doctor of Medicine"
                },
                "period": {
                  "start": "1995"
                },
                "issuer": {
                  "display": "Example University"
                }
              }
            ]
          }
        }
      ]
    },
    "locations": null
  }
}
```

## Testing the FHIRPath error

Add line `raise FhirpathServiceError, "FHIRPath service returned 500 for query '#{fhirpath_query}' on resource #{hash.to_json}: `sample body`"` to the beginning of method `delegate_execution_to_fhirpath_engine` in file `lib/davinci_crd_test_kit/cross_suite/fhirpath_on_cds_request.rb` so that all fhirpath execution fails. Start the suite and follow the following two procedures:

### Test the error on prefetch checking and response generation

1. start a CRD client v2.2.1 session using any version of us core
2. apply preset "Run against the CRD Server Suite"
3. Run group 1.2.6 order-sign and populate the "Custom response for order-sign hook requests" input with a custom response that adds coverage-information a extension to each entry in the draftOrders Bundle. Use the example [here](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Controlling-Simulated-Responses#cominfernoresourceselectioncriteria-extension) as a template, but make the coverage-information extension valid json by removing the "..." and the comma before it.
4. Once a wait dialog appears, create a CRD server v2.2.1 session
5. apply preset "Run against the CRD Client Suite"
6. Run server group 1 Discovery
7. When it completes, run server group 3.6 order-sign with no changes to inputs
8. When it completes, return to the client session and click the link to continue the tests. Attest to the display of responses when another wait dialog appears to complete the tests.
9. Verify that test 1.2.6.3.04 is a purple error result with details asking the tester to submit a ticket
10. Verify that the response to the request associated with test 1.2.6.3.04 is a 500 with a similar error indicating that the tester should check their response template and requests for issues.

