### PR TITLE
FQM-277: Verify configuration options

### DIFF
--- a/lib/davinci_crd_test_kit/cross_suite/tags.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/tags.rb
@@ -14,6 +14,7 @@ module DaVinciCRDTestKit
   HOOK_INSTANCE_DATA_FETCH_TAG_PREFIX = 'hi_data_fetch_'.freeze
   LONG_RUNNING_GROUP_TAG = 'long_running_request'.freeze
   DUPLICATED_HOOK_INSTANCE_TAG = 'duplicate_hook_instance'.freeze
+  COVERAGE_INFO_DISABLED_TAG = 'coverage-info-disabled'.freeze
 
   module TagMethods
     def hook_instance_tag(hook_instance)

--- a/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
+++ b/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
@@ -100,7 +100,7 @@ module DaVinciCRDTestKit
           MockEHR::FHIRRequestHandler.session_id_to_token(@test_session_id, fhir_authorization['expires_in'].to_i / 60)
       end
 
-      def send_hook_invocation(request_body)
+      def send_hook_invocation(request_body, extra_tags = [])
         token = JwtHelper.build(
           aud: @service_endpoint,
           iss: @inferno_base_url,
@@ -110,7 +110,7 @@ module DaVinciCRDTestKit
         )
         headers = { 'Content-type' => 'application/json', 'Authorization' => "Bearer #{token}" }
         response = invoke_hook(request_body, headers)
-        persist_hook_request(response, [@request_tag], headers)
+        persist_hook_request(response, [@request_tag] + extra_tags, headers)
         response
       end
 
@@ -124,7 +124,7 @@ module DaVinciCRDTestKit
         configured_request_body = JSON.parse(request_body.to_json)
         prepare_hook_request(configured_request_body)
         disable_coverage_info_configuration!(configured_request_body)
-        send_hook_invocation(configured_request_body.to_json)
+        send_hook_invocation(configured_request_body.to_json, [COVERAGE_INFO_DISABLED_TAG])
         @coverage_info_configuration_invoked = true
       end
 

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
@@ -16,12 +16,53 @@ module DaVinciCRDTestKit
 
       input :cds_services
 
+      def verify_unique_values(hook, service)
+        unique_fields = ['code', 'name', 'description']
+
+        config_options =
+          service
+            .dig('extension', 'davinci-crd.configuration-options')
+
+        return if config_options.blank?
+
+        unique_fields.each do |unique_field|
+          value_counts =
+            config_options
+              .map { |config_option| config_option[unique_field] }
+              .tally
+
+          duplicate_values =
+            value_counts
+              .select { |_value, count| count > 1 }
+              .keys
+
+          next if duplicate_values.blank?
+
+          duplicate_values_string = duplicate_values.map { |value| "\n- `#{value}`" }.join
+
+          add_message(
+            'error',
+            "Services for hook `#{hook}` contain duplicate values for `#{unique_field}`:" \
+            "#{duplicate_values_string}"
+          )
+        end
+      end
+
       run do
         services = JSON.parse(cds_services)['services']
 
+        services_by_hook = services.group_by { |service| service['hook'] }
+
+        services_by_hook.each do |hook, hook_services|
+          hook_services.each { |service| verify_unique_values(hook, service) }
+        end
+
         primary_hooks = ['appointment-book', 'order-sign', 'order-dispatch']
 
-        primary_hook_services = services.select { |service| primary_hooks.include? service['hook'] }
+        primary_hook_services = services_by_hook.slice(*primary_hooks).values.flatten
+
+        assert messages.none? { |message| message[:type] == 'error' },
+               'Some services contain invalid configuration options.'
 
         omit_if primary_hook_services.blank?, 'No services for primary hooks found'
 

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
@@ -81,7 +81,7 @@ module DaVinciCRDTestKit
             type = config_option[field_name].class
             add_message(
               'error',
-              "Expected hook `#{hook}` service `#{service['id']}` configuration option `#{service['code']}` " \
+              "Expected hook `#{hook}` service `#{service['id']}` configuration option `#{config_option['code']}` " \
               "field `#{field_name}` to be a String, but found #{type}"
             )
           end

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
@@ -10,8 +10,8 @@ module DaVinciCRDTestKit
           type of card they support
 
         This test verifies that all primary hook services contain at least one
-        valid configuration option. Secondary hooks are not expected to return
-        cards, so they are ignored in this test.
+        valid configuration option for `coverage-info`. Secondary hooks are not
+        expected to return cards, so they are ignored in this test.
       )
 
       input :cds_services

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
@@ -15,6 +15,8 @@ module DaVinciCRDTestKit
       )
 
       input :cds_services
+      input :crd_discovery_service_ignore_list,
+            optional: true
 
       def primary_hooks
         ['appointment-book', 'order-sign', 'order-dispatch']
@@ -87,7 +89,10 @@ module DaVinciCRDTestKit
       end
 
       run do
-        services = JSON.parse(cds_services)['services']
+        ignore_list = crd_discovery_service_ignore_list.to_s.split(',').map(&:strip).reject(&:blank?)
+        services =
+          JSON.parse(cds_services)['services']
+            .reject { |service| ignore_list.include? service['id'] }
 
         services_by_hook = services.group_by { |service| service['hook'] }
 

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
@@ -16,6 +16,18 @@ module DaVinciCRDTestKit
 
       input :cds_services
 
+      def primary_hooks
+        ['appointment-book', 'order-sign', 'order-dispatch']
+      end
+
+      def primary_hook?(hook)
+        primary_hooks.include? hook
+      end
+
+      def required_fields
+        ['code', 'type', 'name', 'description', 'default']
+      end
+
       def verify_unique_values(hook, service)
         unique_fields = ['code', 'name', 'description']
 
@@ -48,16 +60,43 @@ module DaVinciCRDTestKit
         end
       end
 
+      def verify_required_fields(hook, service)
+        service.dig('extension', 'davinci-crd.configuration-options')&.each do |config_option|
+          required_fields.each do |field_name|
+            unless config_option.key?(field_name)
+              add_message(
+                'error',
+                "Hook `#{hook}` service `#{service['id']}` configuration option `#{config_option['code']}` " \
+                "does not contain `#{field_name}` field"
+              )
+              next
+            end
+
+            next if field_name == 'default'
+
+            next if config_option[field_name].is_a? String
+
+            type = config_option[field_name].class
+            add_message(
+              'error',
+              "Expected hook `#{hook}` service `#{service['id']}` configuration option `#{service['code']}` " \
+              "field `#{field_name}` to be a String, but found #{type}"
+            )
+          end
+        end
+      end
+
       run do
         services = JSON.parse(cds_services)['services']
 
         services_by_hook = services.group_by { |service| service['hook'] }
 
         services_by_hook.each do |hook, hook_services|
-          hook_services.each { |service| verify_unique_values(hook, service) }
+          hook_services.each do |service|
+            verify_required_fields(hook, service)
+            verify_unique_values(hook, service)
+          end
         end
-
-        primary_hooks = ['appointment-book', 'order-sign', 'order-dispatch']
 
         primary_hook_services = services_by_hook.slice(*primary_hooks).values.flatten
 
@@ -79,44 +118,18 @@ module DaVinciCRDTestKit
           )
         end
 
-        required_fields = ['code', 'type', 'name', 'description', 'default']
-
         primary_hook_services.each do |service|
           coverage_info_config_found =
             service.dig('extension', 'davinci-crd.configuration-options')&.any? do |config_option|
               config_option['code'] == 'coverage-info'
             end
 
-          unless coverage_info_config_found
-            add_message(
-              'error',
-              "Service `#{service['id']}` does not contain a `coverage-info` configuration option"
-            )
-          end
+          next if coverage_info_config_found
 
-          service.dig('extension', 'davinci-crd.configuration-options')&.each do |config_option|
-            required_fields.each do |field_name|
-              unless config_option.key?(field_name)
-                add_message(
-                  'error',
-                  "Service `#{service['id']}` configuration option `#{config_option['code']}` " \
-                  "does not contain `#{field_name}` field"
-                )
-                next
-              end
-
-              next if field_name == 'default'
-
-              next if config_option[field_name].is_a? String
-
-              type = config_option[field_name].class
-              add_message(
-                'error',
-                "Expected service `#{service['id']}` configuration option `#{service['code']}` " \
-                "field `#{field_name}` to be a String, but found #{type}"
-              )
-            end
-          end
+          add_message(
+            'error',
+            "Service `#{service['id']}` does not contain a `coverage-info` configuration option"
+          )
         end
 
         assert messages.none? { |message| message[:type] == 'error' },

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_configuration_test.rb
@@ -1,0 +1,86 @@
+module DaVinciCRDTestKit
+  module V221
+    class DiscoveryConfigurationTest < Inferno::Test
+      title 'Server makes configuration options available'
+      id :crd_v221_discovery_configuration
+      description %(
+        According to the spec:
+
+        > CRD servers SHALL, at minimum, offer configuration options for each
+          type of card they support
+
+        This test verifies that all primary hook services contain at least one
+        valid configuration option. Secondary hooks are not expected to return
+        cards, so they are ignored in this test.
+      )
+
+      input :cds_services
+
+      run do
+        services = JSON.parse(cds_services)['services']
+
+        primary_hooks = ['appointment-book', 'order-sign', 'order-dispatch']
+
+        primary_hook_services = services.select { |service| primary_hooks.include? service['hook'] }
+
+        omit_if primary_hook_services.blank?, 'No services for primary hooks found'
+
+        services_without_configuration_options =
+          primary_hook_services.reject do |service|
+            service['extension'].present? && service['extension']['davinci-crd.configuration-options'].present?
+          end
+
+        if services_without_configuration_options.present?
+          add_message(
+            'error',
+            'The following services do not contain any configuration options: ' \
+            "#{services_without_configuration_options.map { |service| service['code'] }.join(', ')}"
+          )
+        end
+
+        required_fields = ['code', 'type', 'name', 'description', 'default']
+
+        primary_hook_services.each do |service|
+          coverage_info_config_found =
+            service.dig('extension', 'davinci-crd.configuration-options')&.any? do |config_option|
+              config_option['code'] == 'coverage-info'
+            end
+
+          unless coverage_info_config_found
+            add_message(
+              'error',
+              "Service `#{service['id']}` does not contain a `coverage-info` configuration option"
+            )
+          end
+
+          service.dig('extension', 'davinci-crd.configuration-options')&.each do |config_option|
+            required_fields.each do |field_name|
+              unless config_option.key?(field_name)
+                add_message(
+                  'error',
+                  "Service `#{service['id']}` configuration option `#{config_option['code']}` " \
+                  "does not contain `#{field_name}` field"
+                )
+                next
+              end
+
+              next if field_name == 'default'
+
+              next if config_option[field_name].is_a? String
+
+              type = config_option[field_name].class
+              add_message(
+                'error',
+                "Expected service `#{service['id']}` configuration option `#{service['code']}` " \
+                "field `#{field_name}` to be a String, but found #{type}"
+              )
+            end
+          end
+        end
+
+        assert messages.none? { |message| message[:type] == 'error' },
+               'Not all primary hook services contain valid configuration options.'
+      end
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_discovery_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_discovery_group.rb
@@ -1,4 +1,5 @@
 require 'tls_test_kit'
+require_relative 'discovery/discovery_configuration_test'
 require_relative 'discovery/discovery_endpoint_test'
 require_relative 'discovery/discovery_services_validation_test'
 
@@ -35,7 +36,8 @@ module DaVinciCRDTestKit
       test from: :tls_version_test do
         title 'CRD Server is secured by transport layer security'
         description <<~DESCRIPTION
-          Under [Privacy, Security, and Safety](https://hl7.org/fhir/us/davinci-crd/STU2/security.html),
+          Under [Privacy, Safety, and
+          Security](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/security.html),
           the CRD Implementation Guide imposes the following rule about TLS:
 
           As per the [CDS Hook specification](https://cds-hooks.hl7.org/2.0/#security-and-safety),
@@ -57,6 +59,7 @@ module DaVinciCRDTestKit
 
       test from: :crd_v221_discovery_endpoint_test
       test from: :crd_v221_discovery_services_validation
+      test from: :crd_v221_discovery_configuration
     end
   end
 end

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
@@ -40,10 +40,6 @@ module DaVinciCRDTestKit
         nil
       end
 
-      def coverage_info_disabled_request?(request)
-        coverage_info_configuration_disabled?(parsed_body(request.request_body))
-      end
-
       run do
         load_tagged_requests(tested_hook_name, COVERAGE_INFO_DISABLED_TAG)
 

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
@@ -21,11 +21,11 @@ module DaVinciCRDTestKit
         coverage-information/form-completion system actions.
       )
 
-      def coverage_info_message(cards, actions, response_index)
+      def coverage_info_message(cards, actions)
         card_summaries = cards.map { |card| card['summary'] }.compact
         action_descriptions = actions.map { |action| action['description'] }.compact
 
-        "Coverage-info disabled server response #{response_index + 1} included coverage-info content despite " \
+        'Coverage-info disabled server response included coverage-info content despite ' \
           "`#{COVERAGE_INFO_CONFIGURATION_CODE}` being set to `false`. " \
           "Cards: #{card_summaries.join(', ')}. System actions: #{action_descriptions.join(', ')}."
       end
@@ -41,47 +41,30 @@ module DaVinciCRDTestKit
       end
 
       run do
-        load_tagged_requests(tested_hook_name)
-        skip_if requests.blank?, "No #{tested_hook_name} request was made in a previous test as expected."
+        load_tagged_requests(tested_hook_name, COVERAGE_INFO_DISABLED_TAG)
 
-        successful_requests = requests.select { |request| request.status == 200 && request.request_body.present? }
-        requests_with_coverage_info = successful_requests
-          .reject { |request| coverage_info_disabled_request?(request) }
-          .select { |request| coverage_info_response?(parsed_body(request.response_body)) }
-
-        skip_if requests_with_coverage_info.empty?,
+        skip_if requests.empty?,
                 "No successful #{tested_hook_name} response contained coverage-info content to suppress."
 
-        coverage_info_disabled_requests = requests
-          .select { |request| request.request_body.present? }
-          .select { |request| coverage_info_disabled_request?(request) }
-
-        if coverage_info_disabled_requests.empty?
-          add_message(
-            'error',
-            "No #{tested_hook_name} request was made with `#{COVERAGE_INFO_CONFIGURATION_CODE}` set to `false`."
-          )
-        end
-
-        coverage_info_disabled_requests.each_with_index do |request, index|
+        requests.each do |request|
           unless request.status == 200
             add_message(
               'error',
-              "Coverage-info disabled server request #{index + 1} returned HTTP #{request.status}; expected HTTP 200."
+              "Coverage-info disabled server request returned HTTP #{request.status}; expected HTTP 200."
             )
             next
           end
 
           response_body = parsed_body(request.response_body)
           unless response_body.is_a?(Hash)
-            add_message('error', "Coverage-info disabled server response #{index + 1} was not valid JSON.")
+            add_message('error', 'Coverage-info disabled server response was not valid JSON.')
             next
           end
 
           cards, actions = coverage_info_content(response_body)
           next if cards.empty? && actions.empty?
 
-          add_message('error', coverage_info_message(cards, actions, index))
+          add_message('error', coverage_info_message(cards, actions))
         end
 
         assert_no_error_messages('Coverage-info configuration responses were not valid. Check messages for details.')

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
@@ -30,6 +30,10 @@ module DaVinciCRDTestKit
           "Cards: #{card_summaries.join(', ')}. System actions: #{action_descriptions.join(', ')}."
       end
 
+      def primary_hook?
+        ['appointment-book', 'order-sign', 'order-dispatch'].include? tested_hook_name
+      end
+
       def parsed_body(json)
         JSON.parse(json)
       rescue JSON::ParserError
@@ -43,8 +47,14 @@ module DaVinciCRDTestKit
       run do
         load_tagged_requests(tested_hook_name, COVERAGE_INFO_DISABLED_TAG)
 
-        skip_if requests.empty?,
-                "No successful #{tested_hook_name} response contained coverage-info content to suppress."
+        if requests.empty?
+          message = "No successful #{tested_hook_name} response contained coverage-info content to suppress."
+          if primary_hook?
+            skip message
+          else
+            omit message
+          end
+        end
 
         requests.each do |request|
           unless request.status == 200

--- a/spec/davinci_crd_test_kit/v2.2.1/coverage_info_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/coverage_info_configuration_test_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DaVinciCRDTestKit::V221::CoverageInfoConfigurationTest do
   let(:suite_id) { 'crd_client' }
   let(:runnable) { described_class }
   let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
 
   let(:service_endpoint) { 'http://example.com/cds-services/order-sign-service' }
   let(:hook_request) do
@@ -55,7 +56,12 @@ RSpec.describe DaVinciCRDTestKit::V221::CoverageInfoConfigurationTest do
     }
   end
 
-  def create_service_request(body: original_response, status: 200, request_body: hook_request)
+  def create_service_request(
+    body: original_response,
+    status: 200,
+    request_body: hook_request,
+    tags: [DaVinciCRDTestKit::ORDER_SIGN_TAG]
+  )
     repo_create(
       :request,
       direction: 'outgoing',
@@ -63,8 +69,17 @@ RSpec.describe DaVinciCRDTestKit::V221::CoverageInfoConfigurationTest do
       test_session_id: test_session.id,
       request_body: request_body.to_json,
       response_body: body.to_json,
+      result:,
       status:,
+      tags:,
       headers: nil
+    )
+  end
+
+  def create_disabled_service_request(**args)
+    create_service_request(
+      **args,
+      tags: [DaVinciCRDTestKit::ORDER_SIGN_TAG, DaVinciCRDTestKit::COVERAGE_INFO_DISABLED_TAG]
     )
   end
 
@@ -85,26 +100,20 @@ RSpec.describe DaVinciCRDTestKit::V221::CoverageInfoConfigurationTest do
       .messages
   end
 
-  def mock_previous_requests(*requests)
+  before do
     allow_any_instance_of(runnable).to receive(:tested_hook_name).and_return('order-sign')
-    allow_any_instance_of(runnable).to receive(:requests).and_return(requests)
   end
 
   it 'passes when coverage-info disabled responses omit coverage-info content' do
-    original_request = create_service_request
-    disabled_request =
-      create_service_request(body: filtered_response, request_body: coverage_info_disabled_request_body)
-    mock_previous_requests(original_request, disabled_request)
+    create_disabled_service_request(body: filtered_response, request_body: coverage_info_disabled_request_body)
 
     result = run(runnable)
 
-    expect(result.result).to eq('pass')
+    expect(result.result).to eq('pass'), result.result_message
   end
 
   it 'fails if the coverage-info disabled response still contains coverage-info content' do
-    original_request = create_service_request
-    disabled_request = create_service_request(request_body: coverage_info_disabled_request_body)
-    mock_previous_requests(original_request, disabled_request)
+    create_disabled_service_request(request_body: coverage_info_disabled_request_body)
 
     result = run(runnable)
 
@@ -113,24 +122,12 @@ RSpec.describe DaVinciCRDTestKit::V221::CoverageInfoConfigurationTest do
     expect(entity_result_messages.map(&:message).join(' ')).to match(/included coverage-info content/)
   end
 
-  it 'fails if no coverage-info disabled follow-up request was made after coverage-info content was returned' do
-    request = create_service_request
-    mock_previous_requests(request)
-
-    result = run(runnable)
-
-    expect(result.result).to eq('fail')
-    expect(entity_result_messages.map(&:message).join(' '))
-      .to match(/No order-sign request was made with `coverage-info` set to `false`/)
-  end
-
-  it 'skips when prior responses did not include coverage-info content' do
-    request = create_service_request(body: filtered_response)
-    mock_previous_requests(request)
+  it 'skips if no coverage-info disabled follow-up request was made after coverage-info content was returned' do
+    create_service_request
 
     result = run(runnable)
 
     expect(result.result).to eq('skip')
-    expect(result.result_message).to match(/No successful order-sign response contained coverage-info/)
+    expect(result.result_message).to match(/response contained coverage-info content to suppress/)
   end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/coverage_info_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/coverage_info_configuration_test_spec.rb
@@ -122,12 +122,23 @@ RSpec.describe DaVinciCRDTestKit::V221::CoverageInfoConfigurationTest do
     expect(entity_result_messages.map(&:message).join(' ')).to match(/included coverage-info content/)
   end
 
-  it 'skips if no coverage-info disabled follow-up request was made after coverage-info content was returned' do
+  it 'skips if no coverage-info disabled follow-up request was made for primary hooks' do
     create_service_request
 
     result = run(runnable)
 
     expect(result.result).to eq('skip')
+    expect(result.result_message).to match(/response contained coverage-info content to suppress/)
+  end
+
+  it 'omits if no coverage-info disabled follow-up request was made for secondary hooks' do
+    allow_any_instance_of(runnable).to receive(:tested_hook_name).and_return('order-select')
+
+    create_service_request
+
+    result = run(runnable)
+
+    expect(result.result).to eq('omit')
     expect(result.result_message).to match(/response contained coverage-info content to suppress/)
   end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_configuration_test_spec.rb
@@ -115,4 +115,17 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryConfigurationTest do
     expect(result.result).to eq('fail'), result.result_message
     expect(first_error_message.message).to match(/field `description` to be a String, but found Array/)
   end
+
+  it 'fails if configuration options contain duplicate values' do
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [valid_config_option, valid_config_option]
+      }
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(result.result_message).to match(/contain invalid configuration options/)
+    expect(first_error_message.message).to match(/`appointment-book` contain duplicate values for `code`:/)
+  end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_configuration_test_spec.rb
@@ -128,4 +128,27 @@ RSpec.describe DaVinciCRDTestKit::V221::DiscoveryConfigurationTest do
     expect(result.result_message).to match(/contain invalid configuration options/)
     expect(first_error_message.message).to match(/`appointment-book` contain duplicate values for `code`:/)
   end
+
+  it 'ignores services in the ignore list' do
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [valid_config_option]
+      }
+    bad_config_option = valid_config_option.dup
+    bad_config_option.delete 'description'
+    cds_services['services'] << cds_services['services'].first.dup
+    cds_services['services'].last['id'] = 'id_to_ignore'
+    cds_services['services'].last['extension'] =
+      {
+        'davinci-crd.configuration-options' => [bad_config_option]
+      }
+
+    result = run(
+      runnable,
+      cds_services: cds_services.to_json,
+      crd_discovery_service_ignore_list: 'id1, id_to_ignore, id3'
+    )
+
+    expect(result.result).to eq('pass'), result.result_message
+  end
 end

--- a/spec/davinci_crd_test_kit/v2.2.1/discovery_configuration_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/discovery_configuration_test_spec.rb
@@ -1,0 +1,118 @@
+RSpec.describe DaVinciCRDTestKit::V221::DiscoveryConfigurationTest do
+  let(:suite_id) { 'crd_client' }
+  let(:runnable) { described_class }
+  let(:cds_services) do
+    {
+      'services' => [
+        {
+          'hook' => 'appointment-book',
+          'title' => 'Appointment Booking CDS Service',
+          'description' => 'An example of a CDS Service that is invoked when user of a CRD Client books an appointment',
+          'id' => 'appointment-book-service',
+          'prefetch' => {
+            'user' => '{{context.userId}}',
+            'patient' => 'Patient/{{context.patientId}}'
+          }
+        }
+      ]
+    }
+  end
+  let(:valid_config_option) do
+    {
+      'code' => 'coverage-info',
+      'type' => 'boolean',
+      'name' => 'Coverage Information',
+      'description' => 'Placeholder Coverage Info Description',
+      'default' => false
+    }
+  end
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:first_error_message) do
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first
+      .messages.select { |message| message.type == 'error' }
+      .first
+  end
+
+  it 'passes if all primary hook services contain configuration options' do
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [valid_config_option]
+      }
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('pass'), result.result_message
+  end
+
+  it 'passes if secondary hook services do not contain configuration options' do
+    cds_services['services'] << cds_services['services'].first.dup
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [valid_config_option]
+      }
+    cds_services['services'].last['hook'] = 'encounter-start'
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('pass'), result.result_message
+  end
+
+  it 'omits if no primary hook services are found' do
+    cds_services['services'].first['hook'] = 'encounter-start'
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('omit'), result.result_message
+  end
+
+  it 'fails if a primary hook service does not have a coverage-info option' do
+    valid_config_option['code'] = 'claim'
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [valid_config_option]
+      }
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(first_error_message.message).to match(/does not contain a `coverage-info`/)
+  end
+
+  it 'fails if a primary hook service does not have a configuration option' do
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(first_error_message.message).to match(/The following services do not contain any/)
+  end
+
+  it 'fails if a configuration option does not contain a required field' do
+    config_option = valid_config_option
+    config_option.delete 'description'
+
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [config_option]
+      }
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(first_error_message.message).to match(/does not contain `description` field/)
+  end
+
+  it 'fails if a configuration option field is the incorrect type' do
+    config_option = valid_config_option
+    config_option['description'] = ['bad description']
+
+    cds_services['services'].first['extension'] =
+      {
+        'davinci-crd.configuration-options' => [config_option]
+      }
+
+    result = run(runnable, cds_services: cds_services.to_json)
+
+    expect(result.result).to eq('fail'), result.result_message
+    expect(first_error_message.message).to match(/field `description` to be a String, but found Array/)
+  end
+end


### PR DESCRIPTION
# Summary
This branch adds a discovery test to verify that all primary hook services advertise a configuration option for `coverage-info`, the only response type they are required to support.

It also updates the tests which verify the behavior of this option:
- Secondary hooks don't have to support coverage information responses, so the test omits instead of skipping if none are found
- Rather than verifying the response of any request which disables coverage information responses, it chooses a request which is known to return a coverage information response when the configuration option is not disabled

# Testing Guidance
The tests pass running against the client suite. Negative results are verified in unit tests.

# Anticipated Provider-side Test Impact
None