### PR TITLE
ID-112: verify hookInstance uniqueness

### DIFF
--- a/lib/davinci_crd_test_kit/client/endpoints/gather_response_generation_data.rb
+++ b/lib/davinci_crd_test_kit/client/endpoints/gather_response_generation_data.rb
@@ -46,8 +46,8 @@ module DaVinciCRDTestKit
       ]
     }.freeze
 
-    def hook_instance_tag
-      @hook_instance_tag ||= "#{HOOK_INSTANCE_TAG_PREFIX}#{request_body['hookInstance']}"
+    def hook_instance_data_fetch_tag
+      @hook_instance_data_fetch_tag ||= TagMethods.hook_instance_data_fetch_tag(request_body['hookInstance'])
     end
 
     def gather_appointment_book_data
@@ -183,7 +183,7 @@ module DaVinciCRDTestKit
       response = execute_request(reference)
       return nil unless response.present?
 
-      tags = [DATA_FETCH_TAG, hook_instance_tag]
+      tags = [DATA_FETCH_TAG, hook_instance_data_fetch_tag]
       tags << additional_tag if additional_tag.present?
       persist_query_request(response, tags)
       return nil unless response.status.to_s.starts_with?('2')
@@ -296,7 +296,7 @@ module DaVinciCRDTestKit
       response = execute_request(query)
       return nil unless response.present?
 
-      persist_query_request(response, [DATA_FETCH_TAG, hook_instance_tag])
+      persist_query_request(response, [DATA_FETCH_TAG, hook_instance_data_fetch_tag])
       return nil unless response.status.to_s.starts_with?('2')
 
       FHIR.from_contents(response.body)

--- a/lib/davinci_crd_test_kit/client/endpoints/hook_request_endpoint.rb
+++ b/lib/davinci_crd_test_kit/client/endpoints/hook_request_endpoint.rb
@@ -154,13 +154,17 @@ module DaVinciCRDTestKit
 
     def tags
       return [LONG_RUNNING_GROUP_TAG] if long_running_group?
+      return [DUPLICATED_HOOK_INSTANCE_TAG] if hook_instance_already_used?
 
       return [] if invoked_hook != requested_hook ||
                    wrong_hook_for_test? ||
-                   hook_instance_already_used? ||
                    !AVAILABLE_HOOKS.include?(requested_hook)
 
       [hook_instance_tag, hook_or_group_tag]
+    end
+
+    def hook_instance_tag
+      TagMethods.hook_instance_tag(request_body['hookInstance'])
     end
 
     def hook_or_group_tag

--- a/lib/davinci_crd_test_kit/client/v2.0.1/verify_request/hook_request_fetched_data_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.0.1/verify_request/hook_request_fetched_data_test.rb
@@ -49,10 +49,6 @@ module DaVinciCRDTestKit
         assert messages.none? { |msg| msg[:type] == 'error' }, message
       end
 
-      def hook_instance_tag(hook_instance)
-        "#{HOOK_INSTANCE_TAG_PREFIX}#{hook_instance}"
-      end
-
       run do
         hook_requests = load_tagged_requests(*tags_to_load)
 
@@ -65,7 +61,7 @@ module DaVinciCRDTestKit
           end
 
           failed_data_fetches =
-            load_tagged_requests(hook_instance_tag(hook_instance), DATA_FETCH_TAG).reject do |fetch|
+            load_tagged_requests(TagMethods.hook_instance_data_fetch_tag(hook_instance)).reject do |fetch|
               fetch.status.to_s.starts_with?('2')
             end
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_cross_hook_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_cross_hook_group.rb
@@ -1,6 +1,7 @@
 require_relative 'must_support/client_card_must_support_coverage_information_test'
 require_relative 'must_support/client_location_address_propagation_test'
 require_relative 'must_support/client_fhirpath_collection_as_comma_delimited_string_test'
+require_relative 'must_support/client_hook_instances_unique_test'
 
 module DaVinciCRDTestKit
   module V221
@@ -19,6 +20,7 @@ module DaVinciCRDTestKit
       test from: :crd_v221_client_card_must_support_coverage_information
       test from: :crd_v221_client_location_address_propagation
       test from: :crd_v221_client_fhir_path_collection_as_comma_delimited_string
+      test from: :crd_v221_client_hook_instances_unique
     end
   end
 end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/must_support/client_hook_instances_unique_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/must_support/client_hook_instances_unique_test.rb
@@ -1,0 +1,42 @@
+require_relative '../../tagged_request_load_helper'
+require_relative '../../multi_request_message_helper'
+require_relative '../../../cross_suite/tags'
+
+module DaVinciCRDTestKit
+  module V221
+    class ClientHookInstancesUniqueTest < Inferno::Test
+      include TaggedRequestLoadHelper
+      include MultiRequestMessageHelper
+      title 'Request hookInstance values are globally unique'
+      id :crd_v221_client_hook_instances_unique
+      description <<~DESCRIPTION
+        CDS Hooks requires that the `hookInstance` field of each hook
+        request be globally unique so that it can be used for tracking
+        and auditing.
+
+        This test checks that across all hook invocations performed during these
+        tests, the `hookInstance` field was never reused.
+      DESCRIPTION
+
+      config(
+        options: {
+          crd_test_group: DUPLICATED_HOOK_INSTANCE_TAG
+        }
+      )
+
+      run do
+        duplicated_hook_instance_requests = load_hook_requests
+        reused_values = duplicated_hook_instance_requests.map.with_index do |request, request_index|
+          request_body = parse_json_request_entity(request.request_body, 'Request body', request_index)
+          next nil unless request_body.present?
+
+          request_body['hookInstance']
+        end.compact.uniq
+        reused_values.each { |hook_instance| load_tagged_requests(TagMethods.hook_instance_tag(hook_instance)) }
+
+        assert duplicated_hook_instance_requests.blank?,
+               "Inferno received hook requests that re-used `hookInstance` values: #{reused_values.join(', ')}"
+      end
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_coverage_verification_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_coverage_verification_test.rb
@@ -29,8 +29,8 @@ module DaVinciCRDTestKit
             locked: true
 
       def load_payer_request_for_hook_request(request_body)
-        hook_tag = "#{HOOK_INSTANCE_TAG_PREFIX}#{request_body['hookInstance']}"
-        load_tagged_requests(PAYER_ORG_FETCH_TAG, hook_tag, DATA_FETCH_TAG).first
+        hook_data_fetch_tag = TagMethods.hook_instance_data_fetch_tag(request_body['hookInstance'])
+        load_tagged_requests(PAYER_ORG_FETCH_TAG, hook_data_fetch_tag, DATA_FETCH_TAG).first
       end
 
       def check_payer_request(request_body, request_index)

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_data_fetch_verification_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_data_fetch_verification_test.rb
@@ -39,8 +39,8 @@ module DaVinciCRDTestKit
 
         data_returned = hook_requests.any? do |request|
           request_body = JSON.parse(request.request_body)
-          hook_tag = "#{HOOK_INSTANCE_TAG_PREFIX}#{request_body['hookInstance']}"
-          additional_data_requests = load_tagged_requests(hook_tag, DATA_FETCH_TAG)
+          additional_data_requests =
+            load_tagged_requests(TagMethods.hook_instance_data_fetch_tag(request_body['hookInstance']), DATA_FETCH_TAG)
 
           additional_data_requests.any? { |data_request| fhir_data_returned?(data_request) }
         rescue JSON::ParserError

--- a/lib/davinci_crd_test_kit/cross_suite/tags.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/tags.rb
@@ -11,5 +11,19 @@ module DaVinciCRDTestKit
   PAYER_ORG_FETCH_TAG = 'payer_org'.freeze
   PARENT_LOCATION_FETCH_TAG = 'parent_location'.freeze
   HOOK_INSTANCE_TAG_PREFIX = 'hi_'.freeze
+  HOOK_INSTANCE_DATA_FETCH_TAG_PREFIX = 'hi_data_fetch_'.freeze
   LONG_RUNNING_GROUP_TAG = 'long_running_request'.freeze
+  DUPLICATED_HOOK_INSTANCE_TAG = 'duplicate_hook_instance'.freeze
+
+  module TagMethods
+    def hook_instance_tag(hook_instance)
+      "#{HOOK_INSTANCE_TAG_PREFIX}#{hook_instance}"
+    end
+
+    def hook_instance_data_fetch_tag(hook_instance)
+      "#{HOOK_INSTANCE_DATA_FETCH_TAG_PREFIX}#{hook_instance}"
+    end
+
+    module_function :hook_instance_tag, :hook_instance_data_fetch_tag
+  end
 end

--- a/spec/davinci_crd_test_kit/hook_request_endpoint_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_endpoint_spec.rb
@@ -264,9 +264,10 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
       expect(p_request).to have_been_made.once
       expect(pat_request).to have_been_made.once
       expect(cov_request).to have_been_made.once
-      tagged_requests = requests_repo.tagged_requests(test_session.id,
-                                                      [DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
-                                                       DaVinciCRDTestKit::DATA_FETCH_TAG])
+      tagged_requests =
+        requests_repo.tagged_requests(test_session.id,
+                                      [DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
+                                       DaVinciCRDTestKit::DATA_FETCH_TAG])
       expect(tagged_requests.length).to eq(3)
       expect(tagged_requests.one? { |request| request.url == patient_example_reference_absolute }).to be(true)
       expect(tagged_requests.one? { |request| request.url == practitioner_example_reference_absolute }).to be(true)
@@ -346,7 +347,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
         expect(payer_request).to have_been_made.once
         tagged_requests = requests_repo.tagged_requests(
           test_session.id,
-          [DaVinciCRDTestKit::PAYER_ORG_FETCH_TAG, DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
+          [DaVinciCRDTestKit::PAYER_ORG_FETCH_TAG,
+           DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
            DaVinciCRDTestKit::DATA_FETCH_TAG]
         )
         expect(tagged_requests.length).to eq(1)

--- a/spec/davinci_crd_test_kit/hook_request_endpoint_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_endpoint_spec.rb
@@ -84,10 +84,6 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable, scratch)
   end
 
-  def hook_instance_tag(hook_instance)
-    "#{DaVinciCRDTestKit::HOOK_INSTANCE_TAG_PREFIX}#{hook_instance}"
-  end
-
   describe 'When responding' do
     it 'returns 400 when the hookInstance has already been used' do
       allow(test).to receive(:suite).and_return(suite)
@@ -269,7 +265,7 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
       expect(pat_request).to have_been_made.once
       expect(cov_request).to have_been_made.once
       tagged_requests = requests_repo.tagged_requests(test_session.id,
-                                                      [hook_instance_tag(hook_instance),
+                                                      [DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
                                                        DaVinciCRDTestKit::DATA_FETCH_TAG])
       expect(tagged_requests.length).to eq(3)
       expect(tagged_requests.one? { |request| request.url == patient_example_reference_absolute }).to be(true)
@@ -350,7 +346,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
         expect(payer_request).to have_been_made.once
         tagged_requests = requests_repo.tagged_requests(
           test_session.id,
-          [DaVinciCRDTestKit::PAYER_ORG_FETCH_TAG, hook_instance_tag(hook_instance), DaVinciCRDTestKit::DATA_FETCH_TAG]
+          [DaVinciCRDTestKit::PAYER_ORG_FETCH_TAG, DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
+           DaVinciCRDTestKit::DATA_FETCH_TAG]
         )
         expect(tagged_requests.length).to eq(1)
         expect(tagged_requests.first.url).to eq(payer_org_url)
@@ -394,7 +391,8 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
         expect(parent_request).to have_been_made.once
         tagged_requests = requests_repo.tagged_requests(
           test_session.id,
-          [DaVinciCRDTestKit::PARENT_LOCATION_FETCH_TAG, hook_instance_tag(hook_instance),
+          [DaVinciCRDTestKit::PARENT_LOCATION_FETCH_TAG,
+           DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance),
            DaVinciCRDTestKit::DATA_FETCH_TAG]
         )
         expect(tagged_requests.length).to eq(1)

--- a/spec/davinci_crd_test_kit/hook_request_fetched_data_test_spec.rb
+++ b/spec/davinci_crd_test_kit/hook_request_fetched_data_test_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DaVinciCRDTestKit::V201::HookRequestFetchedDataTest do
       request_body: body.is_a?(Hash) ? body.to_json : body,
       status:,
       headers:,
-      tags: ['appointment-book', hook_instance_tag(hook_instance), workflow_tag].compact
+      tags: ['appointment-book', DaVinciCRDTestKit::TagMethods.hook_instance_tag(hook_instance), workflow_tag].compact
     )
   end
 
@@ -63,12 +63,9 @@ RSpec.describe DaVinciCRDTestKit::V201::HookRequestFetchedDataTest do
       request_body: body.is_a?(Hash) ? body.to_json : body,
       status:,
       headers:,
-      tags: [DaVinciCRDTestKit::DATA_FETCH_TAG, hook_instance_tag(hook_instance)]
+      tags: [DaVinciCRDTestKit::DATA_FETCH_TAG,
+             DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(hook_instance)]
     )
-  end
-
-  def hook_instance_tag(hook_instance)
-    "#{DaVinciCRDTestKit::HOOK_INSTANCE_TAG_PREFIX}#{hook_instance}"
   end
 
   def entity_result_message(test, index: 0)

--- a/spec/davinci_crd_test_kit/v2.2.1/client_hook_instances_unique_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/client_hook_instances_unique_test_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../../../lib/davinci_crd_test_kit/cross_suite/tags'
+
+RSpec.describe DaVinciCRDTestKit::V221::ClientHookInstancesUniqueTest do
+  let(:suite_id) { 'crd_client_v221' }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:requests_repo) { Inferno::Repositories::Requests.new }
+  let(:result) { repo_create(:result, test_session_id: test_session.id) }
+  let(:hook_instance_one) { 'd1577c69-dfbe-44ad-ba6d-3e05e953b2ea' }
+  let(:hook_instance_two) { 'd1577c69-dfbe-44ad-ba6d-3e05e953b2eb' }
+  let(:service_url) { 'https://example.com/cds-services/appointment-book-service' }
+  let(:fhir_server) { 'https://fhir.example.com' }
+
+  let(:test) { described_class }
+
+  def create_hook_request(hook_instance,
+                          tags: ['appointment-book', DaVinciCRDTestKit::TagMethods.hook_instance_tag(hook_instance)])
+    body = {
+      'hookInstance' => hook_instance,
+      'hook' => 'appointment-book',
+      'fhirServer' => fhir_server
+    }.compact
+    repo_create(
+      :request,
+      direction: 'incoming',
+      url: service_url,
+      result:,
+      test_session_id: test_session.id,
+      request_body: body.to_json,
+      status: 200,
+      tags:
+    )
+  end
+
+  def result_messages
+    results_repo.current_results_for_test_session_and_runnables(test_session.id, [test])
+      .first
+      .messages
+  end
+
+  it 'passes when no hook requests have been received' do
+    result = run(test)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'passes when all hook request have unique hookInstances' do
+    create_hook_request(hook_instance_one)
+    create_hook_request(hook_instance_two)
+    result = run(test)
+    expect(result.result).to eq('pass')
+  end
+
+  it 'fails when there are multiple hooks calls with the same hookInstance' do
+    create_hook_request(hook_instance_one)
+    create_hook_request(hook_instance_one, tags: [DaVinciCRDTestKit::DUPLICATED_HOOK_INSTANCE_TAG])
+    create_hook_request(hook_instance_two)
+    create_hook_request(hook_instance_two, tags: [DaVinciCRDTestKit::DUPLICATED_HOOK_INSTANCE_TAG])
+    result = run(test)
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to eq('Inferno received hook requests that re-used `hookInstance` values: ' \
+                                        "#{hook_instance_one}, #{hook_instance_two}")
+
+    fetched = results_repo.current_results_for_test_session_and_runnables(test_session.id, [test]).first
+    expect(fetched.requests.uniq(&:id).size).to eq(4)
+  end
+end

--- a/spec/davinci_crd_test_kit/v2.2.1/client_location_address_propagation_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/client_location_address_propagation_test_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../lib/davinci_crd_test_kit/cross_suite/tags'
+
 RSpec.describe DaVinciCRDTestKit::V221::ClienntLocationAddressPropagationTest do
   let(:suite_id) { 'crd_client_v221' }
   let(:runnable) { described_class }
@@ -55,7 +57,7 @@ RSpec.describe DaVinciCRDTestKit::V221::ClienntLocationAddressPropagationTest do
       status:,
       headers: [],
       tags: [DaVinciCRDTestKit::PARENT_LOCATION_FETCH_TAG,
-             "#{DaVinciCRDTestKit::HOOK_INSTANCE_TAG_PREFIX}#{instance}",
+             DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(instance),
              DaVinciCRDTestKit::DATA_FETCH_TAG]
     )
   end

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_coverage_verification_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_coverage_verification_test_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../lib/davinci_crd_test_kit/cross_suite/tags'
+
 RSpec.describe DaVinciCRDTestKit::V221::HookRequestCoverageVerficationTest do
   let(:suite_id) { 'crd_client_v221' }
   let(:runnable) { described_class }
@@ -62,7 +64,8 @@ RSpec.describe DaVinciCRDTestKit::V221::HookRequestCoverageVerficationTest do
       response_body: response_body.is_a?(Hash) ? response_body.to_json : response_body,
       status:,
       headers: [],
-      tags: [DaVinciCRDTestKit::PAYER_ORG_FETCH_TAG, "#{DaVinciCRDTestKit::HOOK_INSTANCE_TAG_PREFIX}#{instance}",
+      tags: [DaVinciCRDTestKit::PAYER_ORG_FETCH_TAG,
+             DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(instance),
              DaVinciCRDTestKit::DATA_FETCH_TAG]
     )
   end

--- a/spec/davinci_crd_test_kit/v2.2.1/hook_request_data_fetch_verification_test_spec.rb
+++ b/spec/davinci_crd_test_kit/v2.2.1/hook_request_data_fetch_verification_test_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../lib/davinci_crd_test_kit/cross_suite/tags'
+
 RSpec.describe DaVinciCRDTestKit::V221::HookRequestDataFetchVerificationTest do
   let(:suite_id) { 'crd_client_v221' }
   let(:hook_name) { 'order-sign' }
@@ -42,7 +44,7 @@ RSpec.describe DaVinciCRDTestKit::V221::HookRequestDataFetchVerificationTest do
       response_body: response_body.is_a?(Hash) ? response_body.to_json : response_body,
       status:,
       headers: [],
-      tags: ["#{DaVinciCRDTestKit::HOOK_INSTANCE_TAG_PREFIX}#{instance}", DaVinciCRDTestKit::DATA_FETCH_TAG]
+      tags: [DaVinciCRDTestKit::TagMethods.hook_instance_data_fetch_tag(instance), DaVinciCRDTestKit::DATA_FETCH_TAG]
     )
   end
 


### PR DESCRIPTION
# Summary

CDS Hooks requires that the `hookInstance` field of each hook request be globally unique so that it can be used for tracking and auditing. The CRD client tests already returned an error result when a hook was invoked with a previously used hookInstance. Now, these are tagged as bad requests and there is also a test that checks for them.

As a part of this update, the data fetch tags were re-factored so that they are completely separate from the hook invocation tags.

# Testing Guidance

## Passing Example

Run client suite against server suite with no changes to inputs
1. start a CRD client v2.2.1 session using any version of us core
2. apply preset "Run against the CRD Server Suite"
3. Run group 1.2.6 order-sign with no changes to inputs
4. Once a wait dialog appears, create a CRD server v2.2.1 session
5. apply preset "Run against the CRD Client Suite"
6. Run server group 1 Discovery
7. When it completes, run server group 3.6 order-sign with no changes to inputs
8. When it completes, return to the client session and click the link to continue the tests. Attest to the display of responses when another wait dialog appears to complete the tests.
9. Run client group 1.3 Cross Hook Verification
10. Verify that test 1.3.04 passes

## Failing Example

Testing this with the server suite requires a code change because the server suite's client simulation generates a new hookInstance on every request it makes.  You can either comment out the first line of method `prepare_hook_request` in file `lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb`, or use an external tool like postman to submit multiple requests with the same hookInstance.

If editing the code. Stop the inferno instance and restart it, then perform the above procedure and verify that test 1.3.04 fails indicating 1 duplicated hookInstance. Verify that all both request, one successful and one failed due to duplicate hookInstance, are associated with the response. The restore your code and stop the inferno instance.



