### PR TITLE
FHIR Server simulation fixes

### DIFF
--- a/lib/davinci_crd_test_kit/server/endpoints/mock_ehr/fhir_request_handler.rb
+++ b/lib/davinci_crd_test_kit/server/endpoints/mock_ehr/fhir_request_handler.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
 
       def token_to_session_id(token_to_decode)
         JSON.parse(Base64.urlsafe_decode64(token_to_decode))&.dig('session_id')
-      rescue JSON::ParserError
+      rescue JSON::ParserError, ArgumentError
         nil
       end
 
@@ -160,7 +160,7 @@ module DaVinciCRDTestKit
 
       def target_resource_present?
         if target_resource.blank?
-          response.status = 400
+          response.status = 404
           response.body = error_body('error', 'not-found',
                                      "No resource found with id #{resource_type}/#{resource_id}")
           return false

--- a/lib/davinci_crd_test_kit/server/endpoints/mock_ehr/fhir_search_endpoint.rb
+++ b/lib/davinci_crd_test_kit/server/endpoints/mock_ehr/fhir_search_endpoint.rb
@@ -473,7 +473,7 @@ module DaVinciCRDTestKit
         key = [resource_type, resource_id]
         return if included_set.include?(key) || matching_entry_set.include?(key)
 
-        included_entry = resolve_refrence_to_entry_in_bundle(resource_type, resource_id)
+        included_entry = resolve_reference_to_entry_in_bundle(resource_type, resource_id)
         return unless included_entry.present?
 
         included_entries << included_entry
@@ -503,7 +503,7 @@ module DaVinciCRDTestKit
         end
       end
 
-      def resolve_refrence_to_entry_in_bundle(resource_type, resource_id)
+      def resolve_reference_to_entry_in_bundle(resource_type, resource_id)
         bundle_entry_index[[resource_type, resource_id]]
       end
 

--- a/spec/davinci_crd_test_kit/mock_ehr/fhir_delete_endpoint_spec.rb
+++ b/spec/davinci_crd_test_kit/mock_ehr/fhir_delete_endpoint_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe DaVinciCRDTestKit::V201::ServerInvokeHookTest, :request do
       expect(last_response.status).to eq(204)
 
       get "/custom/#{suite_id}/fhir/Patient/#{patient.id}"
-      expect(last_response.status).to eq(400)
+      expect(last_response.status).to eq(404)
     end
   end
 end

--- a/spec/davinci_crd_test_kit/mock_ehr/fhir_read_endpoint_spec.rb
+++ b/spec/davinci_crd_test_kit/mock_ehr/fhir_read_endpoint_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe DaVinciCRDTestKit::V201::ServerInvokeHookTest, :request do
       expect(last_response.headers['Content-Type']).to include('application/fhir+json')
     end
 
-    it 'returns 400 with an OperationOutcome when the resource is not found' do
+    it 'returns 404 with an OperationOutcome when the resource is not found' do
       wait_and_auth
       get "/custom/#{suite_id}/fhir/Patient/nonexistent-id"
-      expect(last_response.status).to eq(400)
+      expect(last_response.status).to eq(404)
       outcome = FHIR.from_contents(last_response.body)
       expect(outcome.resourceType).to eq('OperationOutcome')
     end

--- a/spec/davinci_crd_test_kit/mock_ehr/fhir_request_handler_spec.rb
+++ b/spec/davinci_crd_test_kit/mock_ehr/fhir_request_handler_spec.rb
@@ -1,1 +1,25 @@
-# FHIRRequestHandler module logic is tested through the endpoint specs.
+require_relative '../../../lib/davinci_crd_test_kit/server/endpoints/mock_ehr/fhir_request_handler'
+
+RSpec.describe DaVinciCRDTestKit::MockEHR::FHIRRequestHandler do
+  let(:handler) do
+    Class.new { include DaVinciCRDTestKit::MockEHR::FHIRRequestHandler }.new
+  end
+
+  describe '#token_to_session_id' do
+    let(:session_id) { 'abc123' }
+    let(:valid_token) { described_class.session_id_to_token(session_id) }
+
+    it 'decodes a valid token and returns its session_id' do
+      expect(handler.token_to_session_id(valid_token)).to eq(session_id)
+    end
+
+    it 'returns nil when the token contains characters invalid for urlsafe base64' do
+      expect(handler.token_to_session_id('not!!!valid@base64')).to be_nil
+    end
+
+    it 'returns nil when the token is valid base64 but not JSON' do
+      token = Base64.urlsafe_encode64('not json', padding: false)
+      expect(handler.token_to_session_id(token)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
# Summary

This PR fixes some minor issues in the fhir server simulation that is part of the CRD Server tests. Fixes include:
- method name typo fix
- Catch argument errors that can be raised from Base64 decoding during session id extraction
- return 404 when resources aren't found

# Testing Guidance

Verify that the server now returns a 404 on error using the following steps:
1. start a CRD client v2.2.1 session using the 3.1.1 version of us core
2. apply preset "Run against the CRD Server Suite"
3. Run group 1.2.6 order-sign
4. Once a wait dialog appears, create a CRD server v2.2.1 session
5. apply preset "Run against the CRD Client Suite"
6. Run group 1 Discovery
7. When it completes, run group 3.6 order-sign and and clear the "Mock EHR Data" input
8. When it competes, return to the client session and click the link to continue the tests. Attest to the display of responses when another wait dialog appears to complete the tests.
9. check that test 1.2.6.3.06 fails and that requests for `Organization/crd221-demo-payer-complete-prefetch` fail with a 404 HTTP response code.


