### PR TITLE
FQM-282 Update Server Docs for 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Da Vinci Coverage Requirements Discovery (CRD) Test Kit
 
-The **Da Vinci Coverage Requirements Discovery (CRD) STU 2.0.1 Test Kit** validates the 
-conformance of systems to the [CRD STU 2.0.1 FHIR IG](https://hl7.org/fhir/us/davinci-crd/STU2/index.html).
+The **Da Vinci Coverage Requirements Discovery (CRD) Test Kit** validates the
+conformance of systems to multiple versions of the CRD FHIR IG, including
+[CRD STU 2.0.1](https://hl7.org/fhir/us/davinci-crd/STU2/index.html) and
+[CRD STU 2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1).
 For additional details on the tests, including their scope, limitations, and status, see the 
 [Overview](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Overview)
 on the [wiki](https://github.com/inferno-framework/davinci-crd-test-kit/wiki).
@@ -18,8 +20,10 @@ Instructions](#local-installation-instructions) section below for more
 information.
 
 Detailed step-by-step instructions for running the tests can be found in our execution guides:
-- [Client Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Instructions)
-- [Server Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions)
+- [Client v2.0.1 Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Instructions)
+- [Client v2.2.1 Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Instructions-v2.2.1)
+- [Server v2.0.1 Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions)
+- [Server v2.2.1 Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions-v2.2.1)
 
 Additional information is provided in the [Da Vinci CRD Test Kit documentation](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/).
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -85,6 +85,7 @@ issues, please consult the following resources:
   - CDS Hooks Requirements Spreadsheets
     - [v2.0 for CRD v2.0.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_2.0_requirements.xlsx)
     - [v3.0.0-ballot for CRD v2.2.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_3.0.0-ballot_requirements.xlsx)
+    - Note: Although the CRD v2.2.1 [CDS Hooks background section](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/background.html#cds-hooks) references "CDS Hooks 2.0", the IG declares and links to CDS Hooks 3.0.0-ballot; this test kit treats CDS Hooks 3.0.0-ballot as the applicable reference for CRD v2.2.1.
   - [CDS Hooks Library Requirements Spreadsheet](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks-library_1.0.1_requirements.xlsx)
 - [CRD Test Kit GitHub Issues page](https://github.com/inferno-framework/davinci-crd-test-kit/issues).
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -103,4 +103,5 @@ attestation or other means.
 For specific testing prerequisites and detailed test descriptions, refer to:
 * [Client v2.0.1 Suite Testing Instructions](Client-Instructions.md)
 * [Client v2.2.1 Suite Testing Instructions](Client-Instructions-v2.2.1.md)
-* [Server Suite Testing Instructions](Server-Instructions.md)
+* [Server v2.0.1 Suite Testing Instructions](Server-Instructions.md)
+* [Server v2.2.1 Suite Testing Instructions](Server-Instructions-v2.2.1.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,10 @@ to this test kit.
 *   **CDS Hooks Requirements Spreadsheets**: Spreadsheets detailing the interpretation of CDS Hooks specification requirements for this test kit:
     [v2.0 for CRD v2.0.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_2.0_requirements.xlsx)
     and [v3.0.0-ballot for CRD v2.2.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_3.0.0-ballot_requirements.xlsx).
+    Note: Although the CRD v2.2.1
+    [CDS Hooks background section](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/background.html#cds-hooks)
+    references "CDS Hooks 2.0", the IG declares and links to CDS Hooks 3.0.0-ballot;
+    this test kit treats CDS Hooks 3.0.0-ballot as the applicable reference for CRD v2.2.1.
 *   **[CDS Hooks Library Requirements Spreadsheet](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks-library_1.0.1_requirements.xlsx)**: Spreadsheet detailing the interpretation of hook definnition requirements for this test kit.
 
 ## Support

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,9 @@ to this test kit.
 
 ### Using the Da Vinci CRD Server Test Suites 
 *   **[Server Testing Details](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Details)**: Description of the server tests.
-*   **[Server Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions)**: Step-by-step guide for testing server systems, including demonstration executions.
+*   **Server Testing Instructions**: Step-by-step guide for testing server systems, including demonstration executions for both
+    the [v2.0.1 version](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions)
+    and the [v2.2.1 version](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions-v2.2.1)
 
 ## Contributing to this Test Kit
 
@@ -37,8 +39,12 @@ to this test kit.
 
 ## Reference Documents
 
-*   **[CRD Requirements Spreadsheet](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/hl7.fhir.us.davinci-crd_2.0.1_requirements.xlsx)**: Spreadsheet detailing the interpretation of CRD IG requirements for this test kit.
-*   **[CDS Hooks Requirements Spreadsheet](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_2.0_requirements.xlsx)**: Spreadsheet detailing the interpretation of CDS Hooks specification requirements for this test kit.
+*   **CRD Requirements Spreadsheets**: Spreadsheets detailing the interpretation of CRD IG requirements for this test kit:
+    [v2.0.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/hl7.fhir.us.davinci-crd_2.0.1_requirements.xlsx)
+    and [v2.2.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/hl7.fhir.us.davinci-crd_2.2.1_requirements.xlsx).
+*   **CDS Hooks Requirements Spreadsheets**: Spreadsheets detailing the interpretation of CDS Hooks specification requirements for this test kit:
+    [v2.0 for CRD v2.0.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_2.0_requirements.xlsx)
+    and [v3.0.0-ballot for CRD v2.2.1](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks_3.0.0-ballot_requirements.xlsx).
 *   **[CDS Hooks Library Requirements Spreadsheet](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/requirements/cds-hooks-library_1.0.1_requirements.xlsx)**: Spreadsheet detailing the interpretation of hook definnition requirements for this test kit.
 
 ## Support

--- a/docs/Server-Details.md
+++ b/docs/Server-Details.md
@@ -1,63 +1,96 @@
 # Server Suite Implementation Details
 
-The Da Vinci CRD Server Suite validates the conformance of server systems 
-to the STU 2 version of the HL7® FHIR® 
-[Da Vinci Coverage Requirements Discovery Implementation Guide](https://hl7.org/fhir/us/davinci-crd/STU2/).
+The Da Vinci CRD Test Kit contains suites validating the conformance of server systems
+to two versions of the HL7® FHIR® Da Vinci Coverage Requirements Discovery Implementation Guide:
+- [v2.0.1](https://hl7.org/fhir/us/davinci-crd/STU2)
+- [v2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1)
 
-These tests are a **DRAFT** intended to allow CRD server implementers to perform 
-preliminary checks of their servers against CRD IG requirements and [provide 
-feedback](https://github.com/inferno-framework/davinci-crd-test-kit/issues) 
-on the tests. Future versions of these tests may validate other 
+These tests are a **DRAFT** intended to allow CRD server implementers to perform
+preliminary checks of their servers against CRD IG requirements and [provide
+feedback](https://github.com/inferno-framework/davinci-crd-test-kit/issues)
+on the tests. Future versions of these tests may validate other
 requirements and may change the test validation logic.
 
 ## Technical Implementation
 
-In this test suite, Inferno simulates a CRD client system and will make CDS Hooks
-invocations against the tested CRD server system. Over the course of these requests,
-Inferno will seek to observe conformant handling of invocations for supported
-[CRD hooks](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html) and
-the demonstration of cards and actions conforming to the supported
-[CRD card profiles](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html).
+In these suites, Inferno simulates a CRD client system and makes CDS Hooks invocations
+against the tested CRD server system. Over the course of these requests, Inferno seeks
+to observe conformant handling of invocations for supported CRD hooks
+([v2.0.1](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html),
+[v2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html)) and the
+demonstration of cards and actions conforming to the supported CRD response types
+([v2.0.1](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html),
+[v2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html)).
 
-This suite contains three groups of tests:
-1. The *Discovery* group validates a CRD server's discovery response.
-2. The *Demonstrate A Hook Response* group validates that the server
-    can respond to a single hook invocation and return conformant cards.
-3. The *Hooks* group makes one or more CDS Hooks calls for each hook
-    type that the tester provides request bodies for. It then validates that the
-    responses are conformant and cover the full range of cards as
-    required by the hook type.
+The server suites each contain three top-level groups:
+1. The "Discovery" group validates a CRD server's discovery response.
+1. The "Demonstrate A Hook Response" group validates that the server can respond
+   to a single hook invocation and return conformant cards and actions.
+1. The "Hook Tests" group makes one or more CDS Hooks calls for each hook type
+   that the tester provides request bodies for. It then validates that the responses
+   are conformant and cover the response behavior required by the hook type.
 
-All requests and responses will be checked for conformance to the CRD
-IG and CDS Hooks requirements individually and used in aggregate to determine whether
-required features and functionality are present. HL7® FHIR® resources are 
-validated with the Java validator using `tx.fhir.org` as the terminology server.
+All requests and responses are checked for conformance to the targeted CRD IG and
+CDS Hooks requirements individually and used in aggregate to determine whether
+required features and functionality are present. HL7® FHIR® resources are validated
+with the Java validator using `tx.fhir.org` as the terminology server. CDS Hooks
+request and response objects may also be checked using the validator against defined
+logical models in versions that support them, such as
+[v2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/artifacts.html#structures-logical-models).
 
 ### Trusting Inferno's CDS Client
 
 As specified in the [CDS Hooks Spec](https://cds-hooks.hl7.org/2.0/#trusting-cds-clients),
 each time a CDS client transmits a request to a CDS Service which requires authentication,
-the request MUST include an Authorization header presenting the JWT as a “Bearer” token:
-`Authorization:  Bearer {{JWT}}`
+the request MUST include an Authorization header presenting the JWT as a Bearer token:
+`Authorization: Bearer {{JWT}}`
 
 Inferno self-issues the JWT for each CDS Service call and details on the issuer and the JWKS
-are provided during suite execution. They will follow the following pattern:
+are provided during suite execution. They follow these patterns:
 
-- **ISS**: `<inferno base>/custom/crd_server`
-- **JWK Set Url**: `<inferno base>/custom/crd_server/jwks.json`
+| Suite | ISS | JWK Set URL |
+| --- | --- | --- |
+| v2.0.1 | `<inferno base>/custom/crd_server` | `<inferno base>/custom/crd_server/jwks.json` |
+| v2.2.1 | `<inferno base>/custom/crd_server_v221` | `<inferno base>/custom/crd_server_v221/jwks.json` |
 
-Inferno base is the address of the Inferno deployment, such as `https://inferno.healthit.gov/suites`
-for the publicly hosted deployment of this test kit.
+Inferno base is the address of the Inferno deployment, such as
+`https://inferno.healthit.gov/suites` for the publicly hosted deployment of this test kit.
 
 ### CDS Hooks Requests
 
-Because the business logic that determines the details of responses
-Is outside of the CRD specification and will vary between implementers, testers
-are required to provide the requests that Inferno will make to the tested server.
-This way, testers do not need to configure Inferno-specific details, but instead
-tell Inferno what details to send that will allow the server to demonstrate its
-full CRD capabilities. Inferno will check that the requests provided are
+Because the business logic that determines the details of responses is outside of the CRD
+specification and will vary between implementers, testers are required to provide the requests
+that Inferno will make to the tested server. This way, testers do not need to configure
+Inferno-specific details, but instead tell Inferno what details to send that will allow the
+server to demonstrate its full CRD capabilities. Inferno checks that the requests provided are
 conformant and systems will not pass the tests if they are not.
+
+While Inferno is making hook requests, it can also expose a simulated FHIR API backed by the
+resources in the **Mock EHR Data** input. This lets a tested CRD server retrieve additional
+information from Inferno's simulated CRD client during hook processing.
+
+### CRD Server v2.0.1 Suite
+
+The Da Vinci CRD Server v2.0.1 Test Suite targets
+[CRD STU 2.0.1](https://hl7.org/fhir/us/davinci-crd/STU2). It validates discovery,
+basic hook invocation behavior, request structure, response card/action structure,
+and support for CRD response types that can be demonstrated through tester-supplied
+hook request bodies.
+
+### CRD Server v2.2.1 Suite
+
+The Da Vinci CRD Server v2.2.1 Test Suite targets
+[CRD v2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1). It follows the same overall
+workflow as the v2.0.1 suite and adds checks for v2.2.1-specific behavior including:
+- CRD version declarations in discovery through the `davinci-crd.version` extension.
+- Configuration option declarations in discovery, including `coverage-info` options for primary hooks:
+  `appointment-book`, `order-sign`, and `order-dispatch`.
+- Required Coverage Information system actions for primary hooks when the request resource does not
+  already contain a coverage-information extension.
+- Handling of the `coverage-info=false` configuration option when advertised as supported.
+- Tolerance of unknown configuration values, unknown context values, and unknown CDS Hooks fields.
+- Demonstration of coverage-information extension must support elements across the test session.
+- Demonstration that the billing-options extension is not required for the server to respond.
 
 ## Testing Limitations
 
@@ -66,12 +99,19 @@ types to support. These tests try to provide testers with an opportunity to
 exercise as much of their systems as they wish and validate that the exercised
 behaviors are correct. However, not all areas of the IG are exercised.
 
-Specific limitations include:
+General limitations across all server versions include:
 - Inferno is unable to determine what requests will result in specific kinds
-  of responses from the server under test (e.g., what will result in
-  Instructions being returned vs. Coverage Information). As a result, the
-  tester must supply the request bodies that will cause the system under test
-  to return the desired response types.
-- The ability of a CRD server to request additional FHIR resources is not
-  tested.
+  of responses from the server under test, such as Instructions or Coverage Information.
+  As a result, the tester must supply the request bodies that will cause the system under
+  test to return the desired response types.
+- Inferno's simulated FHIR API is limited to the resources supplied in the **Mock EHR Data**
+  input and does not model all behavior of a production EHR FHIR server.
+- The ability of a CRD server to request additional FHIR resources is not exhaustively tested.
+
+### Additional v2.0.1 Server Suite Limitations
+
 - Hook configuration is not tested.
+
+### Additional v2.2.1 Server Suite Limitations
+
+- TODO

--- a/docs/Server-Details.md
+++ b/docs/Server-Details.md
@@ -113,5 +113,7 @@ General limitations across all server versions include:
 - Hook configuration is not tested.
 
 ### Additional v2.2.1 Server Suite Limitations
-
-- TODO
+*Note: this is not an exhaustive set of limitations; this section will be updated soon.*
+- The server suite is not configured to validate responses using FHIR logical models, and
+  instead uses custom logic within the tests.  Future versions may leverage the logical
+  models provided by CRD to standardize the validation of this content.

--- a/docs/Server-Instructions-v2.2.1.md
+++ b/docs/Server-Instructions-v2.2.1.md
@@ -1,6 +1,6 @@
 # Da Vinci CRD Server v2.2.1 Test Suite Testing Instructions
 
-- TODO: Update for v2.2.1. This is a copy from 2.0
+*Note: This section has not been updated to fully document updates made in v2.2.1; it will be updated soon*
 
 This document provides a step-by-step guide for using the Da Vinci CRD Server v2.2.1 Test Suite to test
 a **CRD server system**, including instructions for a [demonstration execution](#demonstration-execution)

--- a/docs/Server-Instructions-v2.2.1.md
+++ b/docs/Server-Instructions-v2.2.1.md
@@ -1,6 +1,8 @@
-# Da Vinci CRD Server v2.0.1 Test Suite Testing Instructions
+# Da Vinci CRD Server v2.2.1 Test Suite Testing Instructions
 
-This document provides a step-by-step guide for using the Da Vinci CRD Server v2.0.1 Test Suite to test
+- TODO: Update for v2.2.1. This is a copy from 2.0
+
+This document provides a step-by-step guide for using the Da Vinci CRD Server v2.2.1 Test Suite to test
 a **CRD server system**, including instructions for a [demonstration execution](#demonstration-execution)
 against the public [CRD server reference implementation](https://crd.davinci.hl7.org/).
 
@@ -15,7 +17,7 @@ Once those details are available, test execution can start.
 
 To execute a simple set of tests targeting a single hook follow these steps:
 
-1. Create a "Da Vinci CRD Server v2.0.1 Test Suite" session.
+1. Create a "Da Vinci CRD Server v2.2.1 Test Suite" session.
 1. Select group "1 Discovery" from the list at the left and click the "RUN TESTS" button
    in the upper right.
 1. In the inputs, provide the details gathered above and click the "SUBMIT" button. Inferno
@@ -53,7 +55,7 @@ If you would like to try out the order-sign hook invocation tests against
 [the public CRD reference server](https://crd.davinci.hl7.org/),
 you can do so using the following steps:
 
-1. Create a "Da Vinci CRD Server v2.0.1 Test Suite" session.
+1. Create a "Da Vinci CRD Server v2.2.1 Test Suite" session.
 1. Select the *CRD Server RI* option from the Preset dropdown in the upper left.
 1. Click the "RUN ALL TESTS" button in the upper right and click "SUBMIT"
 1. Inferno will perform several hook invocations and complete the test run. Note that all

--- a/docs/Technical-Overview.md
+++ b/docs/Technical-Overview.md
@@ -53,7 +53,7 @@ Within the `client` and `server` actor directories, files are generally organize
     later use during evaluation.
   - [*`gather_response_generation_data.rb`*](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/client/endpoints/gather_response_generation_data.rb):
     Used by `hook_request_endpoint.rb` to make FHIR requests against the invoking client's FHIR APIs. The scope of these requests is
-    different for [v2.0.1](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Details#data-fetching-during-hook-invocations) and [v2.2.0](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Details#prefetch-and-additional-data-retrieval).
+    different for [v2.0.1](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Details#data-fetching-during-hook-invocations) and [v2.2.1](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Details#prefetch-and-additional-data-retrieval).
   - [*`mock_service_response.rb`*](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/client/endpoints/mock_service_response.rb):
     Used by *hook_request_endpoint.rb* to create simple mocked hook responses based on types selected when running the tests. Templates
     for the responses live in the [`mocked_card_responses` subdirectory](https://github.com/inferno-framework/davinci-crd-test-kit/tree/main/lib/davinci_crd_test_kit/client/endpoints/mocked_card_responses)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -12,7 +12,8 @@
 
 **Server Suites**
 *   [Server Testing Details](Server-Details)
-*   [Server Testing Instructions](Server-Instructions)
+*   [Server v2.0.1 Testing Instructions](Server-Instructions)
+*   [Server v2.2.1 Testing Instructions](Server-Instructions-v2.2.1)
 
 **Contributing to this Test Kit**
 *   [Technical Overview](Technical-Overview)

--- a/lib/davinci_crd_test_kit/server/v2.0.1/crd_server_suite.rb
+++ b/lib/davinci_crd_test_kit/server/v2.0.1/crd_server_suite.rb
@@ -24,7 +24,7 @@ module DaVinciCRDTestKit
           organization, including its components and limitations.
         - [Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions)
           for a step-by-step guide to execution of these
-          tests against a CRD client, including [instructions for a demonstration execution](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions#demonstration-execution)
+          tests against a CRD server, including [instructions for a demonstration execution](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions#demonstration-execution)
           against the [public reference implementation](https://crd.davinci.hl7.org/).
       DESCRIPTION
 

--- a/lib/davinci_crd_test_kit/server/v2.2.1/crd_server_suite.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/crd_server_suite.rb
@@ -14,27 +14,31 @@ module DaVinciCRDTestKit
       id :crd_server_v221
       title 'Da Vinci CRD Server v2.2.1 Test Suite'
       description <<~DESCRIPTION
-        The Da Vinci CRD Server Test Suite tests the conformance of server systems
-        to [version 2.0.1 of the Da Vinci Coverage Requirements Discovery (CRD)
-        Implementation Guide](https://hl7.org/fhir/us/davinci-crd/STU2).
+        The Da Vinci CRD Server v2.2.1 Test Suite tests the conformance of systems to the
+        capabilities of a CRD server as described in [version 2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1)
+        of the Da Vinci Coverage Requirements Discovery (CRD) Implementation Guide.
 
-        For details on the design and use of these tests, see the wiki including
-        - [Suite Details](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Details)
-          for a high-level description of the test
-          organization, including its components and limitations.
-        - [Testing Instructions](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions)
-          for a step-by-step guide to execution of these
-          tests against a CRD client, including [instructions for a demonstration execution](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions#demonstration-execution)
-          against the [public reference implementation](https://crd.davinci.hl7.org/).
+        Detailed information about this test suite can be found in the
+        [server section](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Details) of the
+        [CRD Test Kit Wiki](https://github.com/inferno-framework/davinci-crd-test-kit/wiki), including:
+        - [What testers need to successfully execute these tests](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions-v2.2.1#pre-execution-setup-and-required-information),
+        - [Minimal](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions-v2.2.1#quick-start)
+          and [complete](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions-v2.2.1#additional-testing-options)
+          instructions for executing against a server system, and
+        - How to [interpret test results](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Server-Instructions-v2.2.1#interpreting-results).
       DESCRIPTION
 
       suite_summary <<~SUMMARY
-        The Da Vinci CRD Server Test Suite tests the conformance of server systems
-        to [version 2.0.1 of the Da Vinci Coverage Requirements Discovery (CRD)
-        Implementation Guide](https://hl7.org/fhir/us/davinci-crd/STU2).
+        The Da Vinci CRD Server v2.2.1 Test Suite tests the conformance of server systems
+        to [version 2.2.1 of the Da Vinci Coverage Requirements Discovery (CRD)
+        Implementation Guide](https://hl7.org/fhir/us/davinci-crd/2.2.1).
       SUMMARY
 
       links [
+        {
+          label: 'Implementation Guide',
+          url: 'https://hl7.org/fhir/us/davinci-crd/2.2.1'
+        },
         {
           label: 'Report Issue',
           url: 'https://github.com/inferno-framework/davinci-crd-test-kit/issues'


### PR DESCRIPTION
# Summary

Updates server docs to match client docs approach for multi-version documentation.  There are a few spots that still need adjustment (noted in the docs themselves), that we plan on getting to early next week.   I wanted to get the main structural updates in place by Tuesday though, so that improvements here are of a 'minor' nature going forward.

# Impact to Client

Note that I took the opportunity to update the main README, just because I saw that it needed to be updated as well.
