### PR TITLE
Fix RegExp warning

### DIFF
--- a/lib/davinci_crd_test_kit/server/v2.2.1/crd_server_suite.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/crd_server_suite.rb
@@ -78,7 +78,7 @@ module DaVinciCRDTestKit
 
         exclude_message do |message|
           message.message.match?(
-            /Appointment\.participant\[.*]: This element does not match any known slice defined in the profile/
+            /Appointment\.participant\[.*\]: This element does not match any known slice defined in the profile/
           ) ||
             message.message.match?(
               /Slice 'Appointment.participant:\w+': a matching slice is required, but not found/


### PR DESCRIPTION
# Summary
A warning pops up for our regexp:

17:21:14 web.1    | /davinci-crd-test-kit/lib/davinci_crd_test_kit/server/v2.2.1/crd_server_suite.rb:81: warning: regular expression has ']' without escape

This fixes that.

# Testing Guidance

Warning should be gone and it shouldn't affect behavior.