### PR TITLE
Update titles to be consistent with guidance.

### DIFF
--- a/docs/Running-Suites-Against-Each-Other.md
+++ b/docs/Running-Suites-Against-Each-Other.md
@@ -55,7 +55,7 @@ of the [v2.2.1 service endpoints](https://github.com/inferno-framework/davinci-c
    1. Once complete, switch to the "subset prefetch" server session and run group "3.x <hook name>"
    1. Once complete, return to the client session and click the link in the "User Action Required" dialog to continue. Attest to the display of cards when the next "User Action Required" dialog appears.
 1. Run client group "1.3 Cross Hook".
-1. Run server group "3.7 Required Card Response Validation" in both server sessions.
+1. Run server group "3.7 Cross-Hook Response Validation" in both server sessions.
 
 Some tests will fail, including
 - TLS tests in the client suite (1.2.x.3.08) and server suites (1.01) will fail when executed in a local system.
@@ -63,13 +63,13 @@ Some tests will fail, including
   on 4 requests each because the server suite purposefully sends non-conformant requests with unexpected
   fields to verify that the server ignores them.
 - Appointment validation in the server suite on tests 3.1.2.02 and 3.1.3.07 due to validator limitations.
-- Coverage Information Must Support in the server suite on tests 3.7.02. Coverage is demonstrated across both
-  server sessions together, but not individually.
+- "Coverage Information responses demonstrate Must Support elements" in the server suite on tests 3.7.02.
+  Coverage is demonstrated across both server sessions together, but not individually.
 
 ### Additional Optional Steps for Long-running Hook Request
 
 1. In the client session, run group "1.4 Long-running Hook Request" with no changes to the inputs.
-1. In the "complete prefetch" server session, run group "2 Demonstrate A Hook Response" with no
+1. In the "complete prefetch" server session, run group "2 Hook Response Demonstration" with no
    changes to the inputs.
 1. Note that a "User Action Required" dialog will appear in the server session with no option to
    continue other than to cancel. This is expected because it is waiting for the client session's
@@ -85,7 +85,7 @@ All tests should pass.
 
 ### Additional Optional Steps for FHIR API Testing
 
-1. In the "subset prefetch" server session, run group "2 Demonstrate A Hook Response", with
+1. In the "subset prefetch" server session, run group "2 Hook Response Demonstration", with
    the following changes to inputs:
    - Update the **Mock EHR Data** input with the contents of the [stress-test-Bundle.json](https://github.com/inferno-framework/davinci-crd-test-kit/blob/main/lib/davinci_crd_test_kit/server/endpoints/mock_ehr/stress-test-Bundle.json)
      file. This contains a complete set of US Core data. NOTE: its size introduces a small amount of lag into the Inferno UI
@@ -101,5 +101,3 @@ Some tests will fail, including:
   automatically update the Bundle with resource updates in `systemActions`.
 - Client test 2.1.11.10 will fail due to an expected conformance issue (this assumes that US Core version 3.1.1 was chosen at client session creation)
 - The server tests will fail as expected because no responses were sent by the client suite.
-
-

--- a/docs/Server-Details.md
+++ b/docs/Server-Details.md
@@ -24,9 +24,11 @@ demonstration of cards and actions conforming to the supported CRD response type
 
 The server suites each contain three top-level groups:
 1. The "Discovery" group validates a CRD server's discovery response.
-1. The "Demonstrate A Hook Response" group validates that the server can respond
-   to a single hook invocation and return conformant cards and actions.
-1. The "Hook Tests" group makes one or more CDS Hooks calls for each hook type
+1. The v2.0.1 "Demonstrate A Hook Response" group and the v2.2.1
+   "Hook Response Demonstration" group validate that the server can respond to
+   a single hook invocation and return conformant cards and actions.
+1. The v2.0.1 "Hook Tests" group and the v2.2.1 "Hooks" group make
+   one or more CDS Hooks calls for each hook type
    that the tester provides request bodies for. It then validates that the responses
    are conformant and cover the response behavior required by the hook type.
 

--- a/docs/Server-Instructions-v2.2.1.md
+++ b/docs/Server-Instructions-v2.2.1.md
@@ -22,8 +22,8 @@ To execute a simple set of tests targeting a single hook follow these steps:
    in the upper right.
 1. In the inputs, provide the details gathered above and click the "SUBMIT" button. Inferno
    will make a discovery request, analyze the details and finish execution.
-1. Select either group "2 Demonstrate A Hook Response" or the sub-group corresponding to the
-   target hook under group "3 Hook Tests". The latter option will perform more in-depth
+1. Select either group "2 Hook Response Demonstration" or the sub-group corresponding to the
+   target hook under group "3 Hooks". The latter option will perform more in-depth
    verification related to the specific hook.
 1. Click the "RUN TESTS" button in the upper right, provide the request body for Inferno
    to use for the invocation in the "Request body ..." input, and click the "SUBMIT" button.

--- a/docs/Technical-Overview.md
+++ b/docs/Technical-Overview.md
@@ -175,6 +175,65 @@ When making changes to the test kit itself, it's important to ensure the changes
     update the relevant documentation files in `/docs/`. These will be automatically mirrored to the repository's
     [GitHub Wiki](https://github.com/inferno-framework/davinci-crd-test-kit/wiki).
 
+## Naming and Style Guidelines
+
+Consistency in naming and documentation helps to make the test kit and its suites clear
+and understandable to users. The maintainers of this repository strongly recommend following
+the naming and style guidelines in this section. See the "Da Vinci CRD Client v2.2.1 Test Suite"
+for an example a suite that follows these guidelines. Other suites in this test kit may not
+currently follow these guidelines.
+
+### Suite, Group, and Test Titles
+
+- **Capitalization scheme**
+  - *Suites* and *Groups*: Capitalize each word of the title of suites and groups.
+  - *Tests*: Capitalize only the first word of test titles.
+  - *Exceptions*: Formal entities from the specifications with specific capitalization schemes,
+    e.g., hook names like `appointment-book` are never capitalized and formal response types
+    defined in the CRD guide like "Coverage Information" are always capitalized.
+- Naming scheme
+  - *Suites*: For suite titles, use the form "<IG> <Actor> <Version> Test Suite",
+    e.g., "Da Vinci CRD Client v2.2.1 Test Suite".
+  - *Groups*: For group titles, use a short noun or noun phrase representing what
+    is being checked within the group, e.g., "Registration", "order-sign", or
+    "Response Handling".
+  - *Tests*: The form of test titles depends on the type of test
+    - Verification tests (most): For tests that verify behavior, use the form 
+      "<Subject> <criteria checked>", e.g., "Client made additional FHIR data available
+      during hook request processing" and "Prefetched resources conform to the required
+      CRD profiles".
+    - Interaction tests: For tests where the primary activity is an interaction, use the
+      form "<Subject> <action>", e.g., "Client invokes the order-sign hook".
+
+### References to Inferno Entiries
+
+- *Suites*, *Groups*, and *Tests*: When referencing an Inferno suite, group, or test,
+  put the name in double quotes. Optionally include the short Id as a prefix. For example,
+  the following phrases are both acceptable:
+  - group "1.1 Registration"
+  - the "Registration" group
+- *Presets*: When referencing a preset, put the name in double quotes.
+- *Inputs*: When referencing an input, **bold** the name.
+
+### Suite, Group, and Test Descriptions
+
+- *Suites*: Suite descriptions should contain brief text with references to additional
+details within this wiki. The following important details should be included or
+highlighted as available on a linked pagee:
+  - Required setup and information needed to run the tests,
+  - Instructions for execution including how to populate inputs, ideally both a
+    minimal and maximal run, and
+  - Details on interpreting the results, including what constitutes a passing session
+    and what limitations a pass result has.
+- *Groups*: Groups don't necessarily need descriptions. When present, group descriptions
+  can provide context, explain how the contained groups/tests are run, and/or
+  explain what a passing run looks like.
+- *Tests*: Tests must have a description. Test descriptions can provide additional
+  context to explain the test and how it works. They must provide a paragraph
+  explaining what the test checks (or does, for interaction tests), starting
+  with “During this test, Inferno will verify …” for verification tetss and
+  “During this test, Inferno will wait for …”
+
 ## Contribution Guidelines
 
 We welcome contributions in the form of bug reports or enhancement suggestions as well as implementations

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_prefetch_support_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_prefetch_support_test.rb
@@ -5,7 +5,7 @@ module DaVinciCRDTestKit
     class DiscoveryPrefetchSupportTest < Inferno::Test
       include DaVinciCRDTestKit::ServerTestHelper
 
-      title 'Server demonstrates ability to request the CDS Client perform prefetch queries'
+      title 'Server advertises prefetch support'
       id :crd_v221_discovery_prefetch_support
       description %(
         This test expects the server to demonstrate support for prefetch queries

--- a/lib/davinci_crd_test_kit/server/v2.2.1/interaction/server_invoke_hook_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/interaction/server_invoke_hook_test.rb
@@ -6,6 +6,7 @@ module DaVinciCRDTestKit
     class ServerInvokeHookTest < ServerAbstractInvokeHookTest
       include ServerURLs
 
+      title 'Inferno invokes the selected hook'
       id :crd_v221_server_invoke_hook_test
 
       def coverage_info_configuration_supported?

--- a/lib/davinci_crd_test_kit/server/v2.2.1/must_support/coverage_information_must_support_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/must_support/coverage_information_must_support_test.rb
@@ -6,7 +6,7 @@ module DaVinciCRDTestKit
     class CoverageInformationMustSupportTest < Inferno::Test
       include DaVinciCRDTestKit::CardsIdentification
 
-      title 'Coverage Information Must Support'
+      title 'Coverage Information responses demonstrate Must Support elements'
       id :crd_v221_coverage_information_must_support
       description <<~DESCRIPTION
         Checks that the server demonstrated must support coverage for the [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/must_support/coverage_information_system_action_across_hooks_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/must_support/coverage_information_system_action_across_hooks_validation_test.rb
@@ -5,7 +5,7 @@ module DaVinciCRDTestKit
     class CoverageInformationSystemActionAcrossHooksValidationTest < Inferno::Test
       include DaVinciCRDTestKit::ServerTestHelper
 
-      title 'Valid Coverage Information system actions received across all hooks'
+      title 'Coverage Information system actions are valid across all hooks'
       id :crd_v221_coverage_info_system_action_across_hooks_validation
       description %(
         This test verifies the presence of valid [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_appointment_book_group.rb
@@ -54,7 +54,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -72,7 +72,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -94,7 +94,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_demonstrate_hook_response_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_demonstrate_hook_response_group.rb
@@ -8,7 +8,7 @@ require_relative 'verify_response/service_response_validation_test'
 module DaVinciCRDTestKit
   module V221
     class ServerDemonstrateHookResponseGroup < Inferno::TestGroup
-      title 'Demonstrate A Hook Response'
+      title 'Hook Response Demonstration'
       id :crd_v221_server_demonstrate_hook_response
       description %(
         This group of tests allows the system to demonstrate its ability to respond to a CRD Hook invocation
@@ -23,7 +23,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -50,7 +50,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -74,7 +74,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_discovery_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_discovery_group.rb
@@ -35,7 +35,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       test from: :tls_version_test do
-        title 'CRD Server is secured by transport layer security'
+        title 'CRD server uses TLS 1.2 or higher'
         description <<~DESCRIPTION
           Under [Privacy, Safety, and
           Security](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/security.html),

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
@@ -46,7 +46,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -64,7 +64,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -86,7 +86,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
@@ -46,7 +46,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -64,7 +64,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -86,7 +86,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
@@ -9,7 +9,7 @@ require_relative 'server_required_card_response_validation_group'
 module DaVinciCRDTestKit
   module V221
     class ServerHooksGroup < Inferno::TestGroup
-      title 'Hook Tests'
+      title 'Hooks'
       id :crd_v221_server_hooks
       description %(
         # Background

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
@@ -54,7 +54,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -72,7 +72,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -94,7 +94,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
@@ -52,7 +52,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -70,7 +70,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -92,7 +92,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_sign_group.rb
@@ -60,7 +60,7 @@ module DaVinciCRDTestKit
       run_as_group
 
       group do
-        title 'Make Hook Requests'
+        title 'Interaction'
 
         test from: :crd_v221_server_invoke_hook_test,
              config: {
@@ -78,7 +78,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Requests'
+        title 'Requests'
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {
@@ -100,7 +100,7 @@ module DaVinciCRDTestKit
       end
 
       group do
-        title 'Verify Responses'
+        title 'Responses'
 
         test from: :crd_v221_service_response_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_context_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_context_validation_test.rb
@@ -9,7 +9,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerTestHelper
       include DaVinciCRDTestKit::ServerHookHelper
 
-      title 'All service requests contain valid context'
+      title 'Service request contexts are valid'
       id :crd_v221_service_request_context_validation
       description %(
         This test verifies that all service requests `context` field is valid and contains all the

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_optional_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_optional_fields_validation_test.rb
@@ -7,7 +7,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerHookRequestValidation
       include DaVinciCRDTestKit::ServerHookHelper
 
-      title 'All service requests contain optional fields'
+      title 'Service request optional fields are valid'
       id :crd_v221_service_request_optional_fields_validation
       description %(
         This optional test reviews the user-submitted CRD service requests for the presence of optional fields:

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_required_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_required_fields_validation_test.rb
@@ -7,7 +7,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerHookRequestValidation
       include DaVinciCRDTestKit::ServerHookHelper
 
-      title 'All service requests contain required fields'
+      title 'Service requests contain required fields'
       id :crd_v221_service_request_required_fields_validation
       description %(
         This test validates all CRD service requests provided by the user, ensuring each includes all required fields

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/additional_orders_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/additional_orders_validation_test.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::CardsIdentification
       include DaVinciCRDTestKit::CardsValidation
 
-      title 'Valid Additional Orders as companions/prerequisites cards received'
+      title 'Additional Orders cards are valid'
       id :crd_v221_additional_orders_card_validation
       description %(
         This test validates that an [Additional Orders as companions/prerequisites](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#identify-additional-orders-as-companionsprerequisites-for-current-order)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/all_responses_include_coverage_information_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/all_responses_include_coverage_information_test.rb
@@ -10,7 +10,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerHookHelper
       include DaVinciCRDTestKit::CardsIdentification
 
-      title 'All hook responses include Coverage Information system action'
+      title 'Hook responses include Coverage Information system actions'
       id :crd_v221_all_responses_include_coverage_information
       description %(
         This test validates that a [Coverage

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_info_configuration_test.rb
@@ -9,7 +9,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerHookHelper
       include DaVinciCRDTestKit::V221::ServerURLs
 
-      title 'Coverage information configuration option suppresses coverage-info responses'
+      title 'Coverage Information configuration option suppresses coverage-info responses'
       id :crd_v221_coverage_info_configuration
       description %(
         This test checks follow-up hook requests made with

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_information_system_action_received_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_information_system_action_received_test.rb
@@ -9,7 +9,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerHookHelper
       include DaVinciCRDTestKit::CardsIdentification
 
-      title 'Coverage Information system action was received'
+      title 'Server returns a Coverage Information system action'
       id :crd_v221_coverage_info_system_action_received
       description %(
         This test validates that a [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_information_system_action_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/coverage_information_system_action_validation_test.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
 
       COVERAGE_INFO_EXT_URL = 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/ext-coverage-information'.freeze
 
-      title 'All Coverage Information system actions received are valid'
+      title 'Coverage Information system actions are valid'
       id :crd_v221_coverage_info_system_action_validation
       description %(
         This test validates all [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/create_or_update_coverage_info_response_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/create_or_update_coverage_info_response_validation_test.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::CardsIdentification
       include DaVinciCRDTestKit::CardsValidation
 
-      title 'Valid Create or Update Coverage Information cards or system actions received'
+      title 'Create or Update Coverage Information cards and system actions are valid'
       id :crd_v221_create_or_update_coverage_info_response_validation
       description %(
         This test validates the Create or Update Coverage Information cards or system actions received from the

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/external_reference_card_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/external_reference_card_validation_test.rb
@@ -11,7 +11,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::CardsIdentification
       include DaVinciCRDTestKit::CardsValidation
 
-      title 'Valid External Reference cards received'
+      title 'External Reference cards are valid'
       id :crd_v221_external_reference_card_validation
       description %(
         This test verifies the presence of valid External Reference cards within the list of valid cards

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/form_completion_response_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/form_completion_response_validation_test.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::CardsIdentification
       include DaVinciCRDTestKit::CardsValidation
 
-      title 'Valid Request Form Completion cards or system actions received'
+      title 'Request Form Completion cards and system actions are valid'
       id :crd_v221_request_form_completion_response_validation
       description %(
         This test validates the Request Form Completion cards or system actions received from the CRD service,

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/instructions_card_received_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/instructions_card_received_test.rb
@@ -9,7 +9,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ServerHookHelper
       include DaVinciCRDTestKit::CardsIdentification
 
-      title 'Valid Instructions cards received'
+      title 'Instructions cards are valid'
       id :crd_v221_valid_instructions_card_received
       description %(
         This test validates that an [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/launch_smart_app_card_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/launch_smart_app_card_validation_test.rb
@@ -11,7 +11,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::CardsIdentification
       include DaVinciCRDTestKit::CardsValidation
 
-      title 'Valid Launch SMART Application cards received'
+      title 'Launch SMART Application cards are valid'
       id :crd_v221_launch_smart_app_card_validation
       description %(
         This test verifies the presence of valid Launch SMART Application cards within the list of valid cards

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/propose_alternate_request_card_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/propose_alternate_request_card_validation_test.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::CardsIdentification
       include DaVinciCRDTestKit::CardsValidation
 
-      title 'Valid Propose Alternate Request cards received'
+      title 'Propose Alternate Request cards are valid'
       id :crd_v221_propose_alternate_request_card_validation
       description %(
         This test validates that all [Propose Alternate Request](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#propose-alternate-request)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/service_response_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/service_response_validation_test.rb
@@ -9,7 +9,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::ResponseLogicalModelValidation
       include DaVinciCRDTestKit::ServerHookHelper
 
-      title 'All service responses contain valid cards and systemActions'
+      title 'Service responses contain valid cards and systemActions'
       id :crd_v221_service_response_validation
       description %(
         As per the [CDS Hooks spec section on CDS Service

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/verify_response_without_billing_options_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/verify_response_without_billing_options_test.rb
@@ -6,7 +6,7 @@ module DaVinciCRDTestKit
     class VerifyResponseWithoutBillingOptionsTest < Inferno::Test
       include DaVinciCRDTestKit::ServerHookHelper
 
-      title 'Server does not require Billing Options Extension'
+      title 'Server does not require the billing-options extension'
       id :verify_response_without_billing_options
       description <<~DESCRIPTION
         The IG states that, "CRD servers **SHALL NOT** depend on the


### PR DESCRIPTION
# Summary

Applies guidance for group and test naming that were used in client tests over to server tests (see #84).

Note: test and group descriptions were not altered at this point.  The titles are much more visible though, so its easier to update descriptions later.

# Testing Guidance
There should be no difference in test behavior.  The naming of the groups and tests should appear slightly more polished, and consistent with choices made on the client side.

