### PR TITLE
ID-119: Wire non-must-support element check into v2.2.1 client order-sign Requests

### DIFF
--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
@@ -6,6 +6,7 @@ require_relative 'auth/token_payload_test'
 require_relative 'verify_request/hook_request_conformance_test'
 require_relative 'verify_request/hook_request_requested_version_test'
 require_relative 'verify_request/hook_request_prefetch_profiles_test'
+require_relative 'verify_request/hook_request_no_non_ms_test'
 require_relative 'verify_request/hook_request_prefetch_complete_test'
 require_relative 'verify_request/hook_request_granted_scopes_test'
 require_relative 'verify_request/hook_request_secured_transport_test'
@@ -85,6 +86,7 @@ module DaVinciCRDTestKit
         end
         test from: :crd_v221_hook_request_requested_version
         test from: :crd_v221_hook_request_prefetch_profiles
+        test from: :crd_v221_hook_request_no_non_ms
         test from: :crd_v221_hook_request_prefetch_complete
         test from: :crd_v221_hook_request_coverage_verification
         test from: :crd_v221_hook_data_fetch_verification

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_no_non_ms_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_no_non_ms_test.rb
@@ -1,0 +1,51 @@
+require_relative '../../../cross_suite/non_must_support_check'
+require_relative '../../tagged_request_load_helper'
+require_relative '../../multi_request_message_helper'
+
+module DaVinciCRDTestKit
+  module V221
+    class HookRequestNoNonMustSupportTest < Inferno::Test
+      include DaVinciCRDTestKit::NonMustSupportCheck
+      include DaVinciCRDTestKit::TaggedRequestLoadHelper
+      include DaVinciCRDTestKit::MultiRequestMessageHelper
+
+      id :crd_v221_hook_request_no_non_ms
+      title 'Client hook requests contain no non-must-support elements'
+      description %(
+        Da Vinci Burden Reduction guides require that conforming clients SHALL NOT
+        depend on non-must-support elements
+        ([CRD conf-10](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/conformance.html#ci-c-conf-10),
+        [CRD conf-13](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/conformance.html#ci-c-conf-13)).
+        We verify this by ensuring no non-must-support element of the applicable CRD
+        profile is populated in the prefetched resources sent with the hook request.
+
+        Inferno walks each FHIR resource found under the `prefetch` field of every
+        captured hook request and reports any non-must-support element paths or
+        extension URLs that are present.
+      )
+
+      verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@conf-10',
+                            'hl7.fhir.us.davinci-crd_2.2.1@conf-13'
+
+      run do
+        hook_requests = load_hook_requests
+
+        skip_if hook_requests.blank?, "No #{hook_name} hook requests received."
+
+        hook_requests.each_with_index do |request, request_index|
+          hook_request = parse_json_request_entity(request.request_body, 'Request body',
+                                                   request_index)
+          next unless hook_request.present?
+          next unless hook_request.key?('prefetch')
+
+          check_hook_request_non_must_support(hook_request['prefetch'], request_index)
+        end
+
+        assert_no_error_messages(
+          "#{requests_with_errors_prefix}Hook request resources contained non-must-support elements. " \
+          'See Messages for details.'
+        )
+      end
+    end
+  end
+end

--- a/lib/davinci_crd_test_kit/cross_suite/non_must_support_check.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/non_must_support_check.rb
@@ -1,0 +1,84 @@
+require_relative 'hook_request_field_validation'
+
+module DaVinciCRDTestKit
+  # Reusable helper for the "client requests SHALL NOT contain non-must-support
+  # elements" check defined by Da Vinci CRD conf-10 / conf-13 (and PAS conf-12).
+  #
+  # Builds on the inferno-core DSL method `non_must_support_elements_present`
+  # added in ID-119. For each prefetched resource (Bundles flattened) we look up
+  # the CRD profile via {HookRequestFieldValidation#structure_definition_map}
+  # and report any non-must-support element paths or unexpected extension URLs.
+  module NonMustSupportCheck
+    include HookRequestFieldValidation
+
+    # Base FHIR Resource / DomainResource fields. Every FHIR profile inherits them
+    # and few profiles bother to mark them must-support, but clients legitimately
+    # populate them on every resource they send (e.g., `id` is needed for cross-
+    # resource references, `meta.profile` declares conformance). We strip them
+    # from the non-MS report so the check focuses on profile-specific elements
+    # the client actually has a choice about.
+    BASE_RESOURCE_FIELDS = %w[id meta implicitRules language text contained].freeze
+
+    def check_hook_request_non_must_support(prefetch, request_index)
+      prefetch.each do |key, prefetched_resource|
+        next if prefetched_resource.blank?
+
+        @prefetch_template = key
+        check_resource_non_must_support(prefetched_resource, request_index, nil)
+      end
+    end
+
+    private
+
+    def check_resource_non_must_support(prefetched_resource, request_index, bundle_entry_index)
+      if prefetched_resource['resourceType'] == 'Bundle'
+        prefetched_resource['entry']&.each_with_index do |entry, entry_index|
+          next if entry['resource'].blank?
+
+          check_resource_non_must_support(entry['resource'], request_index, entry_index)
+        end
+      elsif prefetched_resource['resourceType'].present?
+        check_non_bundle_resource_non_must_support(prefetched_resource, request_index, bundle_entry_index)
+      end
+    end
+
+    def check_non_bundle_resource_non_must_support(prefetched_resource, request_index, bundle_entry_index)
+      target_crd_profile = structure_definition_map('v221')[prefetched_resource['resourceType']]
+      return unless target_crd_profile.present?
+
+      # structure_definition_map returns canonical URLs like ".../profile-patient|2.2.1".
+      # The external HL7 validator accepts that form, but inferno-core's
+      # `profile_by_url` does an exact match against the unversioned URL stored in
+      # the loaded IG, so we strip the canonical version before the lookup.
+      profile_url = target_crd_profile.split('|').first
+
+      resource = FHIR.from_contents(prefetched_resource.to_json)
+      violations =
+        begin
+          non_must_support_elements_present([resource], profile_url) do |metadata|
+            metadata.must_supports[:elements].reject! do |entry|
+              entry[:must_support] == false && BASE_RESOURCE_FIELDS.include?(entry[:path])
+            end
+          end
+        rescue StandardError => e
+          add_message(
+            'warning',
+            "#{non_must_support_error_prefix(request_index, bundle_entry_index)}" \
+            "skipped non-must-support check for #{prefetched_resource['resourceType']}: #{e.message}"
+          )
+          []
+        end
+
+      violations.each do |violation|
+        prefix = non_must_support_error_prefix(request_index, bundle_entry_index)
+        add_message('error', "#{prefix}non-must-support element present: #{violation}")
+      end
+    end
+
+    def non_must_support_error_prefix(request_index, bundle_entry_index)
+      prefix = "(Request #{request_index + 1}) Prefetch Template '#{@prefetch_template}'"
+      prefix = "#{prefix} Bundle entry #{bundle_entry_index + 1}" if bundle_entry_index.present?
+      "#{prefix} - "
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Adds a new test that verifies CRD client hook requests contain no non-must-support elements (CRD [conf-10](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/conformance.html#ci-c-conf-10), [conf-13](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/conformance.html#ci-c-conf-13)), exercising the new inferno-core DSL added in the companion [PR](https://github.com/inferno-framework/inferno-core/pull/785).