### PR TITLE
FQM-327: Update coverage info response type checking

### DIFF
--- a/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
@@ -89,9 +89,11 @@ module DaVinciCRDTestKit
     end
 
     def coverage_info_system_action_response?(response_body)
-      _cards, actions = coverage_info_content(response_body)
+      return false unless response_body.is_a?(Hash)
 
-      actions.present?
+      return false unless response_body['systemActions'].is_a?(Array)
+
+      response_body['systemActions'].any? { |action| coverage_information_response_type?(action) }
     end
 
     def coverage_info_response?(response_body)
@@ -129,6 +131,7 @@ module DaVinciCRDTestKit
 
     def coverage_information_response_type?(action) # rubocop:disable Metrics/CyclomaticComplexity
       return false unless action.respond_to?(:[])
+      return false unless action['type'] == 'update'
 
       resource = action['resource']&.to_hash
       return false unless COVERAGE_INFO_EXPECTED_RESOURCE_TYPES.include? resource&.dig('resourceType')

--- a/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/cards_identification.rb
@@ -88,6 +88,12 @@ module DaVinciCRDTestKit
       [cards, actions]
     end
 
+    def coverage_info_system_action_response?(response_body)
+      _cards, actions = coverage_info_content(response_body)
+
+      actions.present?
+    end
+
     def coverage_info_response?(response_body)
       cards, actions = coverage_info_content(response_body)
 

--- a/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
+++ b/lib/davinci_crd_test_kit/server/jobs/invoke_hook.rb
@@ -135,7 +135,7 @@ module DaVinciCRDTestKit
       def send_unknown_configuration_invocation(request_body, response)
         return if @unknown_configuration_invoked
         return unless response.status == 200
-        return unless coverage_info_response?(parsed_response_body(response))
+        return unless coverage_info_system_action_response?(parsed_response_body(response))
         return unless test_waiting?
 
         request_body = JSON.parse(request_body.to_json)
@@ -149,7 +149,7 @@ module DaVinciCRDTestKit
       def send_unknown_context_invocation(request_body, response)
         return if @unknown_context_invoked
         return unless response.status == 200
-        return unless coverage_info_response?(parsed_response_body(response))
+        return unless coverage_info_system_action_response?(parsed_response_body(response))
         return unless test_waiting?
 
         request_body = JSON.parse(request_body.to_json)
@@ -163,7 +163,7 @@ module DaVinciCRDTestKit
       def send_unknown_cds_hooks_element_invocation(request_body, response)
         return if @unknown_cds_hooks_element_invoked
         return unless response.status == 200
-        return unless coverage_info_response?(parsed_response_body(response))
+        return unless coverage_info_system_action_response?(parsed_response_body(response))
         return unless test_waiting?
 
         request_body = JSON.parse(request_body.to_json)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/unknown_cds_hooks_elements_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/unknown_cds_hooks_elements_test.rb
@@ -60,7 +60,7 @@ module DaVinciCRDTestKit
             next
           end
 
-          next if coverage_info_response?(response_body)
+          next if coverage_info_system_action_response?(response_body)
 
           add_message(
             'error',

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/unknown_configuration_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/unknown_configuration_test.rb
@@ -60,7 +60,7 @@ module DaVinciCRDTestKit
             next
           end
 
-          next if coverage_info_response?(response_body)
+          next if coverage_info_system_action_response?(response_body)
 
           add_message(
             'error',

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/unknown_context_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_response/unknown_context_test.rb
@@ -60,7 +60,7 @@ module DaVinciCRDTestKit
             next
           end
 
-          next if coverage_info_response?(response_body)
+          next if coverage_info_system_action_response?(response_body)
 
           add_message(
             'error',

--- a/spec/davinci_crd_test_kit/server/jobs/invoke_hook_spec.rb
+++ b/spec/davinci_crd_test_kit/server/jobs/invoke_hook_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe DaVinciCRDTestKit::Jobs::InvokeHook do
           indicator: 'info',
           source: { topic: { code: DaVinciCRDTestKit::CardsIdentification::COVERAGE_INFO_CONFIGURATION_CODE } }
         }
+      ],
+      systemActions: [
+        {
+          type: 'update',
+          resource: {
+            resourceType: 'ServiceRequest',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/us/davinci-crd/StructureDefinition/ext-coverage-information'
+              }
+            ]
+          }
+        }
       ]
     }
   end


### PR DESCRIPTION
# Summary
This branch updates the unknown configuration, context, and element tests to require a coverage info response type rather than also accepting cards whose topic is coverage info. The coverage info configuration test remains unchanged since the configuration option should also filter out those cards.

# Testing Guidance
The tests should still pass when run against each other.

# Anticipated Provider-side Test Impact
None
