### PR TITLE
ID-147: Client doc updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     davinci_crd_test_kit (0.14.0)
-      inferno_core (~> 1.3, >= 1.3.1)
+      inferno_core (~> 1.4, >= 1.4.0)
       jwt (~> 3.2)
       smart_app_launch_test_kit (~> 1.0, >= 1.0.2)
       tls_test_kit (~> 1.0)
@@ -41,7 +41,7 @@ GEM
       reline (>= 0.6.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -159,7 +159,7 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    inferno_core (1.3.1)
+    inferno_core (1.4.0)
       activesupport (~> 7.2.3.1)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -180,15 +180,15 @@ GEM
       kramdown (~> 2.5.2)
       kramdown-parser-gfm (~> 1.1.0)
       mutex_m (~> 0.3.0)
-      oj (= 3.11.0)
+      oj (~> 3.17, >= 3.17.3)
       pastel (~> 0.8.0)
       pry
       pry-byebug
-      puma (~> 5.6.7)
+      puma (~> 8.0, >= 8.0.2)
       rake (~> 13.0)
       roo (~> 2.10.1)
       sequel (~> 5.42.0)
-      sidekiq (~> 7.2.4)
+      sidekiq (~> 7.3.10)
       sqlite3 (~> 1.4)
       thor (~> 1.4)
       tty-markdown (~> 0.7.1)
@@ -253,7 +253,10 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.4)
       version_gem (~> 1.1, >= 1.1.9)
-    oj (3.11.0)
+    oj (3.17.3)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
+    ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -275,7 +278,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (5.6.9)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
@@ -339,11 +342,12 @@ GEM
     rubyzip (2.4.1)
     securerandom (0.4.1)
     sequel (5.42.0)
-    sidekiq (7.2.4)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.19.0)
+    sidekiq (7.3.10)
+      base64
+      connection_pool (>= 2.3.0, < 3)
+      logger
+      rack (>= 2.2.4, < 3.3)
+      redis-client (>= 0.23.0, < 1)
     smart_app_launch_test_kit (1.0.2)
       inferno_core (~> 1.2, >= 1.2.2)
       json-jwt (~> 1.15.3)

--- a/davinci_crd_test_kit.gemspec
+++ b/davinci_crd_test_kit.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'DaVinci CRD Test Kit'
   spec.homepage      = 'https://github.com/inferno-framework/davinci-crd-test-kit'
   spec.license       = 'Apache-2.0'
-  spec.add_dependency 'inferno_core', '~> 1.3', '>= 1.3.1'
+  spec.add_dependency 'inferno_core', '~> 1.4', '>= 1.4.0'
   spec.add_dependency 'jwt', '~> 3.2'
   spec.add_dependency 'smart_app_launch_test_kit', '~> 1.0', '>= 1.0.2'
   spec.add_dependency 'tls_test_kit', '~> 1.0'

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -22,7 +22,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   hl7_validator_service:
-    image: infernocommunity/inferno-resource-validator:1.0.73
+    image: infernocommunity/inferno-resource-validator
     environment:
       # Defines how long validator sessions last if unused, in minutes:
       # Negative values mean sessions never expire, 0 means sessions immediately expire

--- a/docs/Running-Suites-Against-Each-Other.md
+++ b/docs/Running-Suites-Against-Each-Other.md
@@ -2,7 +2,9 @@
 
 During development and debugging, it can be useful to run the client and server suites
 against each other to confirm behavior, design decisions, or bug fixes. The following
-instructions can be used to do so.
+instructions can be used to do so. These instructions do not work when running the
+test kit locally within Docker due to networking restrictions when running without a
+dedicated hostname.
 
 ## v2.0.1
 
@@ -16,7 +18,7 @@ instructions can be used to do so.
    1. In the client session, run group "1.2.x <hook name>" leaving the inputs as is. A
       "User Action Required" dialog will appear indicating that Inferno is waiting for the
       hook invocation.
-   1. In the server session, run the corresponding grou "3.x <hook name>" leaving the inputs
+   1. In the server session, run the corresponding group "3.x <hook name>" leaving the inputs
       as is.
    1. Once the server test are complete, return to the client tests and click the link
       in the "User Action Required" dialog indicating requests are complete to continue the

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_appointment_book_group.rb
@@ -30,7 +30,9 @@ module DaVinciCRDTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-A'
 
-      input_order :cds_jwt_iss, :cds_jwk_set
+      input_order :appointment_book_response_approach,
+                  :appointment_book_selected_response_types,
+                  :appointment_book_custom_response_template
 
       config(
         inputs: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_appointment_book_group.rb
@@ -14,6 +14,7 @@ require_relative 'verify_request/hook_request_data_fetch_verification_test'
 require_relative 'verify_response/inferno_response_validation'
 require_relative 'verify_response/client_display_cards_attest'
 require_relative 'verify_response/hook_response_support_coverage_information_test'
+require_relative 'client_urls'
 
 module DaVinciCRDTestKit
   module V221
@@ -25,6 +26,10 @@ module DaVinciCRDTestKit
         the user is scheduling one or more future encounters/visits for the patient.
         The CRD IG places [additional constraints on the use of the appintment-book hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#appointment-book),
         including the profiles that resources in each request must conform to.
+
+        Inferno's simulated `appointment-book` hook endpoints are available at:
+        - Complete Prefetch: `#{ClientURLs.base_url}#{APPOINTMENT_BOOK_PATH}`
+        - Subset Prefetch: `#{ClientURLs.base_url}#{APPOINTMENT_BOOK_PREFETCH_SUBSET_PATH}`
       DESCRIPTION
       run_as_group
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_discharge_group.rb
@@ -30,7 +30,9 @@ module DaVinciCRDTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-A'
 
-      input_order :cds_jwt_iss, :cds_jwk_set
+      input_order :encounter_discharge_response_approach,
+                  :encounter_discharge_selected_response_types,
+                  :encounter_discharge_custom_response_template
 
       config(
         inputs: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_discharge_group.rb
@@ -25,6 +25,10 @@ module DaVinciCRDTestKit
         the notion of 'discharge' is relevant - typically an inpatient encounter.
         The CRD IG places [additional constraints on the use of the encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-discharge),
         including the profiles that resources in each request must conform to.
+
+        Inferno's simulated `encounter-discharge` hook endpoints are available at:
+        - Complete Prefetch: `#{ClientURLs.base_url}#{ENCOUNTER_DISCHARGE_PATH}`
+        - Subset Prefetch: `#{ClientURLs.base_url}#{ENCOUNTER_DISCHARGE_PREFETCH_SUBSET_PATH}`
       DESCRIPTION
       run_as_group
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_start_group.rb
@@ -24,6 +24,10 @@ module DaVinciCRDTestKit
         when the user is initiating a new encounter. The CRD IG places [additional constraints on the use
         of the encounter-start hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-start),
         including the profiles that resources in each request must conform to.
+
+        Inferno's simulated `encounter-start` hook endpoints are available at:
+        - Complete Prefetch: `#{ClientURLs.base_url}#{ENCOUNTER_START_PATH}`
+        - Subset Prefetch: `#{ClientURLs.base_url}#{ENCOUNTER_START_PREFETCH_SUBSET_PATH}`
       DESCRIPTION
       run_as_group
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_encounter_start_group.rb
@@ -29,7 +29,9 @@ module DaVinciCRDTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-A'
 
-      input_order :cds_jwt_iss, :cds_jwk_set
+      input_order :encounter_start_response_approach,
+                  :encounter_start_selected_response_types,
+                  :encounter_start_custom_response_template
 
       config(
         inputs: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_hooks_group.rb
@@ -4,6 +4,7 @@ require_relative 'client_encounter_start_group'
 require_relative 'client_order_dispatch_group'
 require_relative 'client_order_select_group'
 require_relative 'client_order_sign_group'
+require_relative 'client_urls'
 
 module DaVinciCRDTestKit
   module V221
@@ -28,6 +29,25 @@ module DaVinciCRDTestKit
         The CRD IG does not require support for any specific hook, so all the hook-specific sub-groups are
         optional. A conformant CRD client will have implemented at least one hook and will run and pass
         the hook-specific groups corresponding to each hook that it implements.
+
+        Inferno simulates two CRD discovery endpoints, each with service endpoints for all six CRD hooks
+        but with different service ids:
+        - Discovery endpoint for services requesting the complete [standard prefetch data set](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/foundation.html#standard-prefetch):
+          `#{ClientURLs.discovery_url}`
+          * `appointment-book` service id: `appointment-book-service`
+          * `encounter-start` service id: `encounter-start-service`
+          * `encounter-discharge` service id: `encounter-discharge-service`
+          * `order-select` service id: `order-select-service`
+          * `order-dispatch` service id: `order-dispatch-service`
+          * `order-sign` service id: `order-sign-service`
+        - Discovery endpoint for services requesting the a subset of the [standard prefetch data set](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/foundation.html#standard-prefetch):
+          `#{ClientURLs.prefetch_subset_discovery_url}`
+          * `appointment-book` service id: `appointment-book-subset`
+          * `encounter-start` service id: `encounter-start-subset`
+          * `encounter-discharge` service id: `encounter-discharge-subset`
+          * `order-select` service id: `order-select-subset`
+          * `order-dispatch` service id: `order-dispatch-subset`
+          * `order-sign` service id: `order-sign-subset`
       DESCRIPTION
       id :crd_v221_client_hooks
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_long_running_hook_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_long_running_hook_group.rb
@@ -16,7 +16,7 @@ module DaVinciCRDTestKit
 
       run_as_group
 
-      input_order :cds_jwt_iss
+      input_order :long_running_pause_time
 
       config(
         options: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_dispatch_group.rb
@@ -31,7 +31,9 @@ module DaVinciCRDTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-A', 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-B'
 
-      input_order :cds_jwt_iss, :cds_jwk_set
+      input_order :order_dispatch_response_approach,
+                  :order_dispatch_selected_response_types,
+                  :order_dispatch_custom_response_template
 
       config(
         inputs: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_dispatch_group.rb
@@ -26,6 +26,10 @@ module DaVinciCRDTestKit
         that was not tied to a specific performer. The CRD IG places [additional constraints on the use
         of the order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch),
         including the profiles that resources in each request must conform to.
+
+        Inferno's simulated `order-dispatch` hook endpoints are available at:
+        - Complete Prefetch: `#{ClientURLs.base_url}#{ORDER_DISPATCH_PATH}`
+        - Subset Prefetch: `#{ClientURLs.base_url}#{ORDER_DISPATCH_PREFETCH_SUBSET_PATH}`
       DESCRIPTION
       run_as_group
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_select_group.rb
@@ -30,7 +30,9 @@ module DaVinciCRDTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-A', 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-B'
 
-      input_order :cds_jwt_iss, :cds_jwk_set
+      input_order :order_select_response_approach,
+                  :order_select_selected_response_types,
+                  :order_select_custom_response_template
 
       config(
         inputs: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_select_group.rb
@@ -25,6 +25,10 @@ module DaVinciCRDTestKit
         procedures, labs and other orders). The CRD IG places [additional constraints on the use
         of the order-select hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-select),
         including the profiles that resources in each request must conform to.
+
+        Inferno's simulated `order-select` hook endpoints are available at:
+        - Complete Prefetch: `#{ClientURLs.base_url}#{ORDER_SELECT_PATH}`
+        - Subset Prefetch: `#{ClientURLs.base_url}#{ORDER_SELECT_PREFETCH_SUBSET_PATH}`
       DESCRIPTION
       run_as_group
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
@@ -26,6 +26,10 @@ module DaVinciCRDTestKit
         for medications, procedures, labs and other orders). The CRD IG places [additional constraints on the use
         of the order-sign hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-sign),
         including the profiles that resources in each request must conform to.
+
+        Inferno's simulated `order-sign` hook endpoints are available at:
+        - Complete Prefetch: `#{ClientURLs.base_url}#{ORDER_SIGN_PATH}`
+        - Subset Prefetch: `#{ClientURLs.base_url}#{ORDER_SIGN_PREFETCH_SUBSET_PATH}`
       DESCRIPTION
       run_as_group
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_order_sign_group.rb
@@ -31,7 +31,9 @@ module DaVinciCRDTestKit
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-A', 'hl7.fhir.us.davinci-crd_2.2.1@hook-2-B'
 
-      input_order :cds_jwt_iss, :cds_jwk_set
+      input_order :order_sign_response_approach,
+                  :order_sign_selected_response_types,
+                  :order_sign_custom_response_template
 
       config(
         inputs: {

--- a/lib/davinci_crd_test_kit/client/v2.2.1/client_registration_group.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/client_registration_group.rb
@@ -12,6 +12,12 @@ module DaVinciCRDTestKit
         and vice-versa. Tests in this group confirm the registration of the partner
         system on both ends.
 
+        Inferno simulates two CRD discovery endpoints for the client to connect to:
+        - Discovery endpoint for services requesting the complete [standard prefetch data set](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/foundation.html#standard-prefetch):
+          `#{ClientURLs.discovery_url}`
+        - Discovery endpoint for services requesting the a subset of the [standard prefetch data set](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/foundation.html#standard-prefetch):
+          `#{ClientURLs.prefetch_subset_discovery_url}`
+
         This group must be run before any other tests in the "Hook Invocation" group because inputs
         provided to this group will be used by Inferno for the remainder of the tests
         to identify client requests and verify behavior. The inputs will appear as locked and

--- a/lib/davinci_crd_test_kit/client/v2.2.1/long_running/client_skip_long_running_attestation_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/long_running/client_skip_long_running_attestation_test.rb
@@ -10,9 +10,13 @@ module DaVinciCRDTestKit
       id :crd_v221_client_skip_long_running_attestation_test
       title 'Client allows the user to continue their workflow during long-running requests (Attestation)'
       description %(
-        During this test, the tester will confirm that the client system allowed
-        its user to continue with their workflow while the sytem was waiting for the previous
-        long-running hook request to return.
+        The CRD IG [requires](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/foundation.html#ci-c-found-6)
+        that client systems not block their users while waiting for long-running CRD Hook calls.
+        During this test, the tester will confirm that the client system allows users to continue
+        with their workflow when a hook request is long-running. This could be accomplished,
+        for example, by providing a bypass/continue mechanism when a CRD server is taking too long
+        to respond, or by always running hooks requests in the background and notifying users when they
+        return pertinent information.
       )
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@found-6'
@@ -35,7 +39,7 @@ module DaVinciCRDTestKit
           message: <<~MESSAGE
             **Long Running Request Attestation**:
 
-            I attest that the user had the option to continue their workflow
+            I attest that the user was able to continue their workflow
             while waiting for the long-running hook request to return a response:
 
             [Click here](#{attest_true_url}) if the above statement is **true**.

--- a/lib/davinci_crd_test_kit/client/v2.2.1/long_running/client_skip_long_running_attestation_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/long_running/client_skip_long_running_attestation_test.rb
@@ -8,7 +8,7 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::TaggedRequestLoadHelper
 
       id :crd_v221_client_skip_long_running_attestation_test
-      title 'Client allows the user to continue their workflow during long-running requests (Attestation)'
+      title 'Client allows the user to continue their workflow during long-running requests'
       description %(
         The CRD IG [requires](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/foundation.html#ci-c-found-6)
         that client systems not block their users while waiting for long-running CRD Hook calls.
@@ -18,6 +18,7 @@ module DaVinciCRDTestKit
         to respond, or by always running hooks requests in the background and notifying users when they
         return pertinent information.
       )
+      attestation
 
       verifies_requirements 'hl7.fhir.us.davinci-crd_2.2.1@found-6'
 

--- a/lib/davinci_crd_test_kit/client/v2.2.1/registration/client_service_registration_attestation_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/registration/client_service_registration_attestation_test.rb
@@ -4,7 +4,7 @@ module DaVinciCRDTestKit
       include ClientURLs
 
       id :crd_v221_client_service_registration_attestation
-      title 'CRD client registers Inferno (Attestation)'
+      title 'CRD client registers Inferno'
       description %(
         Inferno simulates two CRD servers which can be discovered at the following endpoints:
         - Complete Prefetch Service Discovery Endpoint: #{ClientURLs.discovery_url}
@@ -21,6 +21,7 @@ module DaVinciCRDTestKit
           of the US Core FHIR API and used to verify the `fhirAuthorization.scope`
           hook request field).
       )
+      attestation
       verifies_requirements 'cds-hooks_3.0.0-ballot@174'
 
       input :complete_prefetch_service_organization_id,

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_response/client_display_cards_attest.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_response/client_display_cards_attest.rb
@@ -10,12 +10,13 @@ module DaVinciCRDTestKit
       include DaVinciCRDTestKit::TaggedRequestLoadHelper
 
       id :crd_v221_card_display_attest_test
-      title 'Client displays returned decision support details to the user (Attestation)'
+      title 'Client displays returned decision support details to the user'
       description %(
         During this test, the tester will confirm that the received cards and actions in the
         hook responses have been displayed or otherwise made available to users of the client system
         in an appopriate way that allows for consideration and action if warranted.
       )
+      attestation
 
       def responded_card_types
         list_card_types_in_requests(requests)


### PR DESCRIPTION
# Summary

Minor documentation updates based on demo experience and feedback

# Testing Guidance

Start a client v2.2.1 session and verify that endpoint information is now viewable in the descriptions for groups:
- "1.1 Registration"
- "1.2 Hooks"
- "1.2.X <hook-name>"

When running the "1.2.X <hook-name>" groups, verify that the locked inputs appear after the editable ones.

