### PR TITLE
FQM-337: Simulation verification labels

### DIFF
--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_appointment_book_group.rb
@@ -73,6 +73,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_demonstrate_hook_response_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_demonstrate_hook_response_group.rb
@@ -51,6 +51,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
@@ -65,6 +65,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
@@ -65,6 +65,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
@@ -73,6 +73,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
@@ -71,6 +71,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_sign_group.rb
@@ -79,6 +79,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/specific_coverage_responses/technical_issues_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/specific_coverage_responses/technical_issues_group.rb
@@ -58,6 +58,7 @@ module DaVinciCRDTestKit
 
       group do
         title 'Requests'
+        simulation_verification
 
         test from: :crd_v221_service_request_required_fields_validation,
              config: {

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_context_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_context_validation_test.rb
@@ -16,6 +16,7 @@ module DaVinciCRDTestKit
         required fields.
       )
       input :contexts, :invoked_hook
+      simulation_verification
 
       run do
         parsed_contexts = parse_json(contexts)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_optional_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_optional_fields_validation_test.rb
@@ -17,6 +17,7 @@ module DaVinciCRDTestKit
         informational message.
       )
       optional
+      simulation_verification
 
       run do
         load_tagged_requests(tested_hook_name)

--- a/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_required_fields_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/verify_request/service_request_required_fields_validation_test.rb
@@ -17,6 +17,7 @@ module DaVinciCRDTestKit
       )
       input :invoked_hook
       output :contexts
+      simulation_verification
 
       run do
         load_tagged_requests(tested_hook_name)


### PR DESCRIPTION
# Summary

This adds simulation verification labels throughout the v2.2.1 server suite.

I added the label at the group level in addition to individual tests. Is this right?

# Testing Guidance

Open the server suite and verify the Simulation Verification labels are present in all the appropriate places

# Anticipated Provider-side Test Impact

None