### PR TITLE
FQM-369: Update server IG links

### DIFF
--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_endpoint_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_endpoint_test.rb
@@ -5,7 +5,7 @@ module DaVinciCRDTestKit
       id :crd_v221_discovery_endpoint_test
       description %(
         A CDS Service provider must expose its discovery endpoint at `{baseURL}/cds-services`
-        as specified in the [CDS Hooks Specification](https://cds-hooks.hl7.org/2.0/#discovery).
+        as specified in the [CDS Hooks Specification](https://cds-hooks.hl7.org/2026Jan/en/index.html#discovery).
 
         This test checks that the server responds to a GET request at the following endpoint:
 

--- a/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/discovery/discovery_services_validation_test.rb
@@ -8,7 +8,7 @@ module DaVinciCRDTestKit
       title 'Discovery response contains valid services'
       id :crd_v221_discovery_services_validation
       description %(
-        As per the [CDS Hooks Spec](https://cds-hooks.hl7.org/2.0/#response),
+        As per the [CDS Hooks Spec](https://cds-hooks.hl7.org/2026Jan/en/index.html#response),
         the response to the discovery endpoint SHALL be an object containing
         a list of CDS services. If your CDS server hosts no CDS services,
         the discovery endpoint should return a 200 HTTP response with

--- a/lib/davinci_crd_test_kit/server/v2.2.1/must_support/coverage_information_system_action_across_hooks_validation_test.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/must_support/coverage_information_system_action_across_hooks_validation_test.rb
@@ -8,7 +8,7 @@ module DaVinciCRDTestKit
       title 'Coverage Information system actions are valid across all hooks'
       id :crd_v221_coverage_info_system_action_across_hooks_validation
       description %(
-        This test verifies the presence of valid [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)
+        This test verifies the presence of valid [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
         system action returned by CRD services across all hooks invoked. It verifies the following for each action:
         - The action type is `update`.
         - The resource within the action conforms its respective FHIR profile.

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_appointment_book_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_appointment_book_group.rb
@@ -23,29 +23,24 @@ module DaVinciCRDTestKit
       description %(
         This group of tests invokes the appointment-book hook and ensures that
         the user-provided requests are valid as per the requirements described
-        in the [CRD IG section on appointment-book hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#appointment-book)
-        and the [CDS Hooks specification section on appointment-book context](https://cds-hooks.hl7.org/hooks/appointment-book/2023SepSTU1Ballot/appointment-book/).
+        in the [CRD IG section on appointment-book hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#appointment-book)
+        and the [CDS Hooks specification section on appointment-book context](https://cds-hooks.hl7.org/hooks/STU1/appointment-book.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
-        the [CRD IG section on appointment-book hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#appointment-book)
-        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
+        the [CRD IG section on appointment-book hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#appointment-book)
+        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
 
-        The [CRD IG section on appointment-book hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#appointment-book)
+        The [CRD IG section on appointment-book hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#appointment-book)
         states that "servers SHALL, at minimum, support returning and processing the Coverage Information
-        system action for all invocations of this hook."
+        system action for all invocations of the appointment-book hook."
 
         This group includes tests to validate the following CRD response types:
-        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)
-        - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
-        - optional
-        - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
-        - [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions) - optional
-        - [Launch SMART application](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#launch-smart-application) -
-        optional
-        - [Request form completion](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#request-form-completion) -
-        optional
+        - [External Reference](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#external-reference-response-type)
+        - [Instructions](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#instructions-response-type)
+        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
+        - [Request Form Completion](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#request-form-completion-response-type)
+        - [Update Coverage Records](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#update-coverage-records-response-type)
+        - [Launch SMART Application](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#launch-smart-application-response-type)
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@164', 'hl7.fhir.us.davinci-crd_2.0.1@168',
-      #                       'hl7.fhir.us.davinci-crd_2.0.1@170', 'hl7.fhir.us.davinci-crd_2.0.1@184'
 
       config options: { hook_name: APPOINTMENT_BOOK_TAG }
       run_as_group

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_demonstrate_hook_response_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_demonstrate_hook_response_group.rb
@@ -13,8 +13,10 @@ module DaVinciCRDTestKit
         and return a valid response. Inferno will use the provided request body and will either use the provided service
         id or infer one from the hook indicated in the request and the server's discovery response.
         It ensures that the user-provided request and the server's response are both
-        valid as per the requirements described in the [CRD IG section](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html)
-        and the [CDS Hooks](https://cds-hooks.hl7.org/) hook specification for the corresponding hook.
+        valid as per the requirements described in the [CRD IG
+        section](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html) and
+        the [CDS Hooks](https://cds-hooks.hl7.org/2026Jan/en/index.html) hook
+        specification for the corresponding hook.
       )
 
       config options: { hook_name: ANY_HOOK_TAG }

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_discovery_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_discovery_group.rb
@@ -13,7 +13,7 @@ module DaVinciCRDTestKit
         # Background
 
         The #{title} Group checks for a CDS Service's Discovery endpoint as described by the
-        [CDS Hooks Specification](https://cds-hooks.hl7.org/2.0/#discovery).
+        [CDS Hooks Specification](https://cds-hooks.hl7.org/2026Jan/en/index.html#discovery).
         A CDS Service is discoverable via a stable endpoint by CDS Clients. The Discovery endpoint
         includes information such as a description of the CDS Service, when it should be invoked,
         and any data that is requested to be prefetched.
@@ -25,7 +25,7 @@ module DaVinciCRDTestKit
         It parses the response and verifies that:
         - The Discovery endpoint is TLS secured.
         - The Discovery endpoint is available at `{baseURL}/cds-services`.
-        - Each CDS Service in the response contains the required fields as specified in the [CDS Hooks Spec](https://cds-hooks.hl7.org/2.0/#response).
+        - Each CDS Service in the response contains the required fields as specified in the [CDS Hooks Spec](https://cds-hooks.hl7.org/2026Jan/en/index.html#response).
 
         It collects the following information that is saved in the testing session for use by later tests:
         - List of supported CDS Services/Hooks
@@ -41,7 +41,7 @@ module DaVinciCRDTestKit
           Security](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/security.html),
           the CRD Implementation Guide imposes the following rule about TLS:
 
-          As per the [CDS Hook specification](https://cds-hooks.hl7.org/2.0/#security-and-safety),
+          As per the [CDS Hook specification](https://cds-hooks.hl7.org/2026Jan/en/index.html#security-and-safety),
           communications between CRD Clients and CRD Servers SHALL
           use TLS. Mutual TLS is not required by this specification but is permitted. CRD Servers and
           CRD Clients SHOULD enforce a minimum version and other TLS configuration requirements based

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
@@ -22,7 +22,7 @@ module DaVinciCRDTestKit
         This group of tests invokes the encounter-discharge hook and ensures that
         the user-provided requests are valid as per the requirements described
         in the [CRD IG section on encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-discharge)
-        and the [CDS Hooks specification section on encounter-discharge context](http://cds-hooks.hl7.org/hooks/STU1/encounter-discharge.html).
+        and the [CDS Hooks specification section on encounter-discharge context](https://cds-hooks.hl7.org/hooks/STU1/encounter-discharge.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
         the [CRD IG section on encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-discharge)
         and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_discharge_group.rb
@@ -21,24 +21,20 @@ module DaVinciCRDTestKit
       description %(
         This group of tests invokes the encounter-discharge hook and ensures that
         the user-provided requests are valid as per the requirements described
-        in the [CRD IG section on encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-discharge)
-        and the [CDS Hooks specification section on encounter-discharge context](https://cds-hooks.hl7.org/hooks/encounter-discharge/2023SepSTU1Ballot/encounter-discharge/).
+        in the [CRD IG section on encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-discharge)
+        and the [CDS Hooks specification section on encounter-discharge context](http://cds-hooks.hl7.org/hooks/STU1/encounter-discharge.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
-        the [CRD IG section on encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-discharge)
-        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
+        the [CRD IG section on encounter-discharge hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-discharge)
+        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
 
         This group includes tests to validate the following CRD response types:
-        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information) - optional
-        - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
-        - optional
-        - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
-        - [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions) - optional
-        - [Launch SMART application](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#launch-smart-application) -
-        optional
-        - [Request form completion](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#request-form-completion) -
-        optional
+        - [External Reference](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#external-reference-response-type)
+        - [Instructions](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#instructions-response-type)
+        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
+        - [Request Form Completion](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#request-form-completion-response-type)
+        - [Update Coverage Records](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#update-coverage-records-response-type)
+        - [Launch SMART Application](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#launch-smart-application-response-type)
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@168', 'hl7.fhir.us.davinci-crd_2.0.1@196'
 
       config options: { hook_name: ENCOUNTER_DISCHARGE_TAG }
       run_as_group

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
@@ -22,7 +22,7 @@ module DaVinciCRDTestKit
         This group of tests invokes the encounter-start hook and ensures that
         the user-provided requests are valid as per the requirements described
         in the [CRD IG section on encounter-start hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-start)
-        and the [CDS Hooks specification section on encounter-start context](http://cds-hooks.hl7.org/hooks/STU1/encounter-start.html).
+        and the [CDS Hooks specification section on encounter-start context](https://cds-hooks.hl7.org/hooks/STU1/encounter-start.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
         the [CRD IG section on encounter-start hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-start)
         and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_encounter_start_group.rb
@@ -21,24 +21,20 @@ module DaVinciCRDTestKit
       description %(
         This group of tests invokes the encounter-start hook and ensures that
         the user-provided requests are valid as per the requirements described
-        in the [CRD IG section on encounter-start hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-start)
-        and the [CDS Hooks specification section on encounter-start context](https://cds-hooks.hl7.org/hooks/encounter-start/2023SepSTU1Ballot/encounter-start/).
+        in the [CRD IG section on encounter-start hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-start)
+        and the [CDS Hooks specification section on encounter-start context](http://cds-hooks.hl7.org/hooks/STU1/encounter-start.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
-        the [CRD IG section on encounter-start hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-start)
-        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
+        the [CRD IG section on encounter-start hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-start)
+        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
 
         This group includes tests to validate the following CRD response types:
-        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information) - optional
-        - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
-        - optional
-        - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
-        - [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions) - optional
-        - [Launch SMART application](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#launch-smart-application) -
-        optional
-        - [Request form completion](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#request-form-completion) -
-        optional
+        - [External Reference](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#external-reference-response-type)
+        - [Instructions](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#instructions-response-type)
+        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
+        - [Request Form Completion](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#request-form-completion-response-type)
+        - [Update Coverage Records](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#update-coverage-records-response-type)
+        - [Launch SMART Application](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#launch-smart-application-response-type)
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@168', 'hl7.fhir.us.davinci-crd_2.0.1@185'
 
       config options: { hook_name: ENCOUNTER_START_TAG }
       run_as_group

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
@@ -14,17 +14,17 @@ module DaVinciCRDTestKit
       description %(
         # Background
 
-        The #{title} Group verifies that a [CRD Server](https://hl7.org/fhir/us/davinci-crd/STU2/CapabilityStatement-crd-server.html)
-        supports at least one of the hooks supported by the [CRD IG](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#supported-hooks).
+        The #{title} Group verifies that a [CRD Server](https://hl7.org/fhir/us/davinci-crd/2.2.1/CapabilityStatement-crd-server.html)
+        supports at least one of the hooks supported by the [CRD IG](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#supported-hooks).
         The supported hooks include:
-        - [appointment-book](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#appointment-book)
-        - [encounter-start](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-start)
-        - [encounter-discharge](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#encounter-discharge)
-        - [order-select](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-select)
-        - [order-dispatch](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-dispatch)
-        - [order-sign](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-sign)
+        - [appointment-book](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#appointment-book)
+        - [encounter-start](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#encounter-start)
+        - [encounter-discharge](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#encounter-discharge)
+        - [order-select](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#order-select)
+        - [order-dispatch](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#order-dispatch)
+        - [order-sign](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#order-sign)
 
-        The [CRD STU2 IG section on Supported Hooks](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#supported-hooks)
+        The [CRD 2.2.1 IG section on Supported Hooks](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#supported-hooks)
         states that "CRD Servers conforming to this implementation guide
         SHALL provide a service for all hooks and order resource types required of
         CRD clients by this implementation guide unless the server has determined that
@@ -33,7 +33,7 @@ module DaVinciCRDTestKit
 
         # Test Methodology
 
-        In these tests, Inferno acts as a [CRD Client](https://hl7.org/fhir/us/davinci-crd/STU2/CapabilityStatement-crd-client.html)
+        In these tests, Inferno acts as a [CRD Client](https://hl7.org/fhir/us/davinci-crd/2.2.1/CapabilityStatement-crd-client.html)
         that initiates CDS Hooks calls. This test sequence is broken up into groups,
         each group corresponding to a supported hook and defining a set of tests verifying
         the ability of the server to respond to the given hook invocation. An
@@ -42,18 +42,13 @@ module DaVinciCRDTestKit
 
         Each hook group test verifies that:
         - The hook can be invoked.
-        - The user-provided request payload contains the required fields as specified
-          in the [CDS Hooks section on HTTP request requirements](https://cds-hooks.hl7.org/2.0/#http-request_1).
-        - The user-provided request payload contains the optional fields as specified
-          in the [CDS Hooks section on HTTP request requirements](https://cds-hooks.hl7.org/2.0/#http-request_1) -
-          optional.
+        - The user-provided request payload is valid as specified
+          in the [CDS Hooks section on HTTP request requirements](https://cds-hooks.hl7.org/2026Jan/en/index.html#http-request-1).
         - Each card and system action returned by the server is valid as described in the
-          [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
-        - Each [CRD response type](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#potential-crd-response-types)
+          [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
+        - Each [CRD response type](https://hl7.org/fhir/us/davinci-crd/2.2.1/cards.html#potential-crd-response-types)
           returned is valid - optional for some response types. See the individual test groups for more details.
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@4', 'hl7.fhir.us.davinci-crd_2.0.1@152',
-      #                       'hl7.fhir.us.davinci-crd_2.0.1@153'
 
       group from: :crd_v221_server_appointment_book,
             optional: true

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
@@ -18,14 +18,14 @@ module DaVinciCRDTestKit
         the hooks supported by the [CRD
         IG](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#supported-hooks).
         The supported hooks include:
-        - [appointment-book](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#appointment-book)
-        - [encounter-start](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#encounter-start)
-        - [encounter-discharge](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#encounter-discharge)
-        - [order-select](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#order-select)
-        - [order-dispatch](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#order-dispatch)
-        - [order-sign](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#order-sign)
+        - [appointment-book](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#appointment-book)
+        - [encounter-start](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-start)
+        - [encounter-discharge](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#encounter-discharge)
+        - [order-select](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-select)
+        - [order-dispatch](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch)
+        - [order-sign](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-sign)
 
-        The [CRD 2.2.1 IG section on Supported Hooks](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#supported-hooks)
+        The [CRD 2.2.1 IG section on Supported Hooks](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#supported-hooks)
         states that "CRD Servers conforming to this implementation guide
         SHALL provide a service for all hooks and order resource types required of
         CRD clients by this implementation guide unless the server has determined that

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_hooks_group.rb
@@ -14,8 +14,9 @@ module DaVinciCRDTestKit
       description %(
         # Background
 
-        The #{title} Group verifies that a [CRD Server](https://hl7.org/fhir/us/davinci-crd/2.2.1/CapabilityStatement-crd-server.html)
-        supports at least one of the hooks supported by the [CRD IG](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#supported-hooks).
+        The #{title} Group verifies that a CRD Server supports at least one of
+        the hooks supported by the [CRD
+        IG](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#supported-hooks).
         The supported hooks include:
         - [appointment-book](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#appointment-book)
         - [encounter-start](https://hl7.org/fhir/us/davinci-crd/2.2.1/hooks.html#encounter-start)
@@ -33,9 +34,9 @@ module DaVinciCRDTestKit
 
         # Test Methodology
 
-        In these tests, Inferno acts as a [CRD Client](https://hl7.org/fhir/us/davinci-crd/2.2.1/CapabilityStatement-crd-client.html)
-        that initiates CDS Hooks calls. This test sequence is broken up into groups,
-        each group corresponding to a supported hook and defining a set of tests verifying
+        In these tests, Inferno acts as a CRD Client that initiates CDS Hooks
+        calls. This test sequence is broken up into groups, each group
+        corresponding to a supported hook and defining a set of tests verifying
         the ability of the server to respond to the given hook invocation. An
         additional group checks that the Coverage Information response type is
         supported for at least one hook.

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
@@ -24,7 +24,7 @@ module DaVinciCRDTestKit
         This group of tests invokes the order-dispatch hook and ensures that
         the user-provided requests are valid as per the requirements described
         in the [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch)
-        and the [CDS Hooks specification section on order-dispatch context](http://cds-hooks.hl7.org/hooks/STU1/order-dispatch.html).
+        and the [CDS Hooks specification section on order-dispatch context](https://cds-hooks.hl7.org/hooks/STU1/order-dispatch.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
         the [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch)
         and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_dispatch_group.rb
@@ -23,29 +23,24 @@ module DaVinciCRDTestKit
       description %(
         This group of tests invokes the order-dispatch hook and ensures that
         the user-provided requests are valid as per the requirements described
-        in the [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-dispatch)
-        and the [CDS Hooks specification section on order-dispatch context](https://cds-hooks.hl7.org/hooks/order-dispatch/2023SepSTU1Ballot/order-dispatch/).
+        in the [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch)
+        and the [CDS Hooks specification section on order-dispatch context](http://cds-hooks.hl7.org/hooks/STU1/order-dispatch.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
-        the [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-dispatch)
-        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
+        the [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch)
+        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
 
-        The [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-dispatch)
+        The [CRD IG section on order-dispatch hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-dispatch)
         states that "servers SHALL, at minimum, support returning and processing the Coverage Information
         system action for all invocations of this hook."
 
         This group includes tests to validate the following CRD response types:
-        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)
-        - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
-        - optional
-        - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
-        - [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions) - optional
-        - [Launch SMART application](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#launch-smart-application) -
-        optional
-        - [Request form completion](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#request-form-completion) -
-        optional
+        - [External Reference](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#external-reference-response-type)
+        - [Instructions](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#instructions-response-type)
+        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
+        - [Request Form Completion](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#request-form-completion-response-type)
+        - [Update Coverage Records](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#update-coverage-records-response-type)
+        - [Launch SMART Application](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#launch-smart-application-response-type)
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@164', 'hl7.fhir.us.davinci-crd_2.0.1@168',
-      #                       'hl7.fhir.us.davinci-crd_2.0.1@204', 'hl7.fhir.us.davinci-crd_2.0.1@207'
 
       config options: { hook_name: ORDER_DISPATCH_TAG }
       run_as_group

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
@@ -24,7 +24,7 @@ module DaVinciCRDTestKit
         This group of tests invokes the order-select hook and ensures that
         the user-provided requests are valid as per the requirements described
         in the [CRD IG section on order-select hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-select)
-        and the [CDS Hooks specification section on order-select context](http://cds-hooks.hl7.org/hooks/STU1/order-select.html).
+        and the [CDS Hooks specification section on order-select context](https://cds-hooks.hl7.org/hooks/STU1/order-select.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
         the [CRD IG section on order-select hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-select)
         and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_select_group.rb
@@ -23,28 +23,22 @@ module DaVinciCRDTestKit
       description %(
         This group of tests invokes the order-select hook and ensures that
         the user-provided requests are valid as per the requirements described
-        in the [CRD IG section on order-select hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-select)
-        and the [CDS Hooks specification section on order-select context](https://cds-hooks.hl7.org/hooks/order-select/2023SepSTU1Ballot/order-select/).
+        in the [CRD IG section on order-select hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-select)
+        and the [CDS Hooks specification section on order-select context](http://cds-hooks.hl7.org/hooks/STU1/order-select.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
-        the [CRD IG section on order-select hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-select)
-        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
+        the [CRD IG section on order-select hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-select)
+        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
 
         This group includes tests to validate the following CRD response types:
-        - [additional orders as companions/prerequisites](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#identify-additional-orders-as-companionsprerequisites-for-current-order)\
-        - optional
-        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information) - optional
-        - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
-        - optional
-        - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
-        - [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions) - optional
-        - [Launch SMART application](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#launch-smart-application) -
-        optional
-        - [Propose alternate request](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#propose-alternate-request) -
-        optional
-        - [Request form completion](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#request-form-completion) -
-        optional
+        - [External Reference](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#external-reference-response-type)
+        - [Instructions](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#instructions-response-type)
+        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
+        - [Propose Alternate Request](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#propose-alternate-request-response-type)
+        - [Identify Additional Orders](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#identify-additional-orders-response-type)
+        - [Request Form Completion](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#request-form-completion-response-type)
+        - [Update Coverage Records](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#update-coverage-records-response-type)
+        - [Launch SMART Application](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#launch-smart-application-response-type)
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@168', 'hl7.fhir.us.davinci-crd_2.0.1@208'
 
       config options: { hook_name: ORDER_SELECT_TAG }
       run_as_group

--- a/lib/davinci_crd_test_kit/server/v2.2.1/server_order_sign_group.rb
+++ b/lib/davinci_crd_test_kit/server/v2.2.1/server_order_sign_group.rb
@@ -25,33 +25,26 @@ module DaVinciCRDTestKit
       description %(
         This group of tests invokes the order-sign hook and ensures that
         the user-provided requests are valid as per the requirements described
-        in the [CRD IG section on order-sign hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-sign)
-        and the [CDS Hooks specification section on order-sign context](https://cds-hooks.hl7.org/hooks/order-sign/2023SepSTU1Ballot/order-sign/).
+        in the [CRD IG section on order-sign hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-sign)
+        and the [CDS Hooks specification section on order-sign context](https://cds-hooks.hl7.org/hooks/STU1/order-sign.html).
         It also ensures that the contents of the server's response are valid as per the requirements described in
-        the [CRD IG section on order-sign hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-sign)
-        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2.0/#cds-service-response).
+        the [CRD IG section on order-sign hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-sign)
+        and the [CDS Hooks section on CDS Service Response](https://cds-hooks.hl7.org/2026Jan/en/#cds-service-response).
 
-        The [CRD IG section on order-sign hook](https://hl7.org/fhir/us/davinci-crd/STU2/hooks.html#order-sign)
+        The [CRD IG section on order-sign hook](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/hooks.html#order-sign)
         states that "servers SHALL, at minimum, support returning and processing the Coverage Information
         system action for all invocations of this hook."
 
         This group includes tests to validate the following CRD response types:
-        - [additional orders as companions/prerequisites](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#identify-additional-orders-as-companionsprerequisites-for-current-order)\
-        - optional
-        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#coverage-information)
-        - [Create or update coverage information](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#create-or-update-coverage-information)\
-        - optional
-        - [External Reference](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#external-reference) - optional
-        - [Instructions](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#instructions) - optional
-        - [Launch SMART application](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#launch-smart-application) -
-        optional
-        - [Propose alternate request](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#propose-alternate-request) -
-        optional
-        - [Request form completion](https://hl7.org/fhir/us/davinci-crd/STU2/cards.html#request-form-completion) -
-        optional
+        - [External Reference](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#external-reference-response-type)
+        - [Instructions](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#instructions-response-type)
+        - [Coverage Information](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#coverage-information-response-type)
+        - [Propose Alternate Request](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#propose-alternate-request-response-type)
+        - [Identify Additional Orders](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#identify-additional-orders-response-type)
+        - [Request Form Completion](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#request-form-completion-response-type)
+        - [Update Coverage Records](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#update-coverage-records-response-type)
+        - [Launch SMART Application](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/cards.html#launch-smart-application-response-type)
       )
-      # verifies_requirements 'hl7.fhir.us.davinci-crd_2.0.1@164', 'hl7.fhir.us.davinci-crd_2.0.1@168',
-      #                       'hl7.fhir.us.davinci-crd_2.0.1@217', 'hl7.fhir.us.davinci-crd_2.0.1@226'
 
       config options: { hook_name: ORDER_SIGN_TAG }
       run_as_group


### PR DESCRIPTION
# Summary
This branch updates descriptions in the 2.2.1 server suite to point at the correct versions of the relevant IGs.

**NOTE:** this branch is currently on top of #125.

# Testing Guidance
This is strictly a documentation update, so there should be no changes in behavior.

# Anticipated Provider-side Test Impact
None.