### PR TITLE
Fix reported CRD Client Bugs

### DIFF
--- a/docs/Client-Instructions-v2.2.1.md
+++ b/docs/Client-Instructions-v2.2.1.md
@@ -166,7 +166,10 @@ With those caveats, a passing execution of this suite would include:
 
 If you would like to try out the order-sign hook invocation tests against
 [the public CRD reference client](https://crd-request-generator.davinci.hl7.org/),
-you can do so using the following steps:
+you can do so using the following steps. Note that this reference implementation has
+not been updated for the 2.2.1 version of the CRD IG so many failures are expected during this
+execution. However, it can give you a sense for what executing the Inferno tests against a 
+client system will look like.
 
 1. Create a "Da Vinci CRD Client v2.2.1 Test Suite" session using the default "US Core Version",
    which will not be used.

--- a/lib/davinci_crd_test_kit/client/endpoints/hook_request_endpoint.rb
+++ b/lib/davinci_crd_test_kit/client/endpoints/hook_request_endpoint.rb
@@ -76,7 +76,11 @@ module DaVinciCRDTestKit
     end
 
     def make_response
-      if invoked_hook != requested_hook
+      if requested_hook.blank?
+        error_response("No hook requested - populate the 'hook' element in the request.",
+                       code: 400,
+                       outcome_code: 'value')
+      elsif invoked_hook != requested_hook
         error_response("#{request.env['PATH_INFO']} serves the #{invoked_hook}, but the client " \
                        "requested the #{requested_hook} hook.",
                        code: 400,
@@ -105,7 +109,7 @@ module DaVinciCRDTestKit
 
     def process_valid_hook
       if ig_version == 'v201'
-        send(:"gather_#{requested_hook.gsub('-', '_')}_data")
+        send(:"gather_#{requested_hook&.gsub('-', '_')}_data")
         request_coverage
       elsif ig_version == 'v221'
         request_additional_fhir_data
@@ -168,7 +172,7 @@ module DaVinciCRDTestKit
                    wrong_hook_for_test? ||
                    !AVAILABLE_HOOKS.include?(requested_hook)
 
-      [hook_instance_tag, hook_or_group_tag]
+      [hook_instance_tag, hook_or_group_tag].compact
     end
 
     def hook_instance_tag
@@ -178,7 +182,7 @@ module DaVinciCRDTestKit
     def hook_or_group_tag
       if test.config.options[:crd_test_group].present?
         test.config.options[:crd_test_group]
-      else
+      elsif name.present?
         DaVinciCRDTestKit.const_get(:"#{name.upcase}_TAG")
       end
     end
@@ -206,7 +210,7 @@ module DaVinciCRDTestKit
     end
 
     def name
-      requested_hook.gsub('-', '_')
+      requested_hook&.gsub('-', '_')
     end
 
     # -----------------------

--- a/lib/davinci_crd_test_kit/client/v2.2.1/crd_client_suite.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/crd_client_suite.rb
@@ -23,6 +23,11 @@ module DaVinciCRDTestKit
         capabilities of a CRD client as described in [version 2.2.1](https://hl7.org/fhir/us/davinci-crd/2.2.1)
         of the Da Vinci Coverage Requirements Discovery (CRD) Implementation Guide.
 
+        These tests are a **DRAFT** intended to allow CRD implementers to perform
+        preliminary checks of their implementations against the CRD IG requirements and
+        [provide feedback](https://github.com/inferno-framework/davinci-crd-test-kit/issues) on the tests.
+        Future versions of these tests may validate other requirements and may change how these are tested.
+
         Detailed information about this test suite can be found in the
         [client section](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Client-Details) of the
         [CRD Test Kit Wiki](https://github.com/inferno-framework/davinci-crd-test-kit/wiki), including:

--- a/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_complete_test.rb
+++ b/lib/davinci_crd_test_kit/client/v2.2.1/verify_request/hook_request_prefetch_complete_test.rb
@@ -29,6 +29,12 @@ module DaVinciCRDTestKit
         During this test, Inferno will verify that each hook request body includes a `prefetch` field populated with
         valid JSON that contains exactly the requested prefetch keys and data sets described in the service description
         for the invoked service as calculated by Inferno based on the resources provided in the request.
+
+        Note that Inferno requires **all** requested prefetch keys to be present in the request even if there is no
+        data for that key. This because the [CDS Hook specification requires](https://cds-hooks.hl7.org/2026Jan/en/#example-of-pagination-in-prefetch)
+        that if "the CDS Client has no data to populate a template prefetch key, the prefetch template key MUST have a
+        value of null." For templates that request the results of a FHIR search interaction, an empty Bundle is also
+        acceptable.
       )
       verifies_requirements 'cds-hooks_3.0.0-ballot@30', 'cds-hooks_3.0.0-ballot@231', 'cds-hooks_3.0.0-ballot@45',
                             'cds-hooks_3.0.0-ballot@46', 'cds-hooks_3.0.0-ballot@47', 'cds-hooks_3.0.0-ballot@232',

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
@@ -201,16 +201,24 @@ module DaVinciCRDTestKit
                   "expected active, got #{prefetched_coverage['status']}."
       end
 
-      target_patient_id = hook_request.dig('context', 'patientId')
-      target_patient_ref =
-        target_patient_id.starts_with?('Patient/') ? target_patient_id : "Patient/#{target_patient_id}"
-      unless prefetched_coverage.dig('beneficiary', 'reference').ends_with?(target_patient_ref)
-        errors << "#{error_prefix} prefetched Coverage has an unexpected beneficiary reference: " \
-                  "expected #{target_patient_ref}, got #{prefetched_coverage.dig('beneficiary',
-                                                                                 'reference')}."
-      end
+      check_coverage_beneficiary(prefetched_coverage)
 
       nil
+    end
+
+    def check_coverage_beneficiary(prefetched_coverage)
+      target_patient_id = hook_request.dig('context', 'patientId')
+      patient_id = target_patient_id&.delete_prefix('Patient/')
+      relative_ref = "Patient/#{patient_id}"
+      fhir_server = hook_request['fhirServer']&.chomp('/')
+      absolute_ref = "#{fhir_server}/#{relative_ref}" if fhir_server.present?
+
+      actual_ref = prefetched_coverage.dig('beneficiary', 'reference')
+      return if actual_ref == relative_ref || (absolute_ref && actual_ref == absolute_ref)
+
+      expected_refs = [relative_ref, absolute_ref].compact.join(' or ')
+      errors << "#{error_prefix} prefetched Coverage has an unexpected beneficiary reference: " \
+                "expected #{expected_refs}, got #{actual_ref}."
     end
 
     def check_read(prefetched_value, instantiated_request)

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
@@ -202,10 +202,12 @@ module DaVinciCRDTestKit
       end
 
       target_patient_id = hook_request.dig('context', 'patientId')
-      unless prefetched_coverage.dig('beneficiary', 'reference').ends_with?("Patient/#{target_patient_id}")
+      target_patient_ref =
+        target_patient_id.starts_with?('Patient/') ? target_patient_id : "Patient/#{target_patient_id}"
+      unless prefetched_coverage.dig('beneficiary', 'reference').ends_with?(target_patient_ref)
         errors << "#{error_prefix} prefetched Coverage has an unexpected beneficiary reference: " \
-                  "expected Patient/#{target_patient_id}, got #{prefetched_coverage.dig('beneficiary',
-                                                                                        'reference')}."
+                  "expected #{target_patient_ref}, got #{prefetched_coverage.dig('beneficiary',
+                                                                                 'reference')}."
       end
 
       nil

--- a/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker.rb
@@ -172,12 +172,16 @@ module DaVinciCRDTestKit
       end
 
       check_is_fhir_resource(prefetched_value, target_resource_type: 'Bundle')
-      unless prefetched_value['entry'].size == 1
-        errors << "#{error_prefix} exactly one Coverage must be provided."
-        return
-      end
+      if prefetched_value['resourceType'] == 'Bundle'
+        unless prefetched_value['entry']&.size == 1
+          errors << "#{error_prefix} exactly one Coverage must be provided."
+          return
+        end
 
-      check_coverage(prefetched_value.dig('entry', 0, 'resource'))
+        check_coverage(prefetched_value.dig('entry', 0, 'resource'))
+      elsif prefetched_value['resourceType'] == 'Coverage'
+        check_coverage(prefetched_value)
+      end
     end
 
     def check_coverage(prefetched_coverage)
@@ -198,7 +202,7 @@ module DaVinciCRDTestKit
       end
 
       target_patient_id = hook_request.dig('context', 'patientId')
-      unless prefetched_coverage.dig('beneficiary', 'reference') == "Patient/#{target_patient_id}"
+      unless prefetched_coverage.dig('beneficiary', 'reference').ends_with?("Patient/#{target_patient_id}")
         errors << "#{error_prefix} prefetched Coverage has an unexpected beneficiary reference: " \
                   "expected Patient/#{target_patient_id}, got #{prefetched_coverage.dig('beneficiary',
                                                                                         'reference')}."

--- a/lib/davinci_crd_test_kit/cross_suite/requests_logical_model_validation.rb
+++ b/lib/davinci_crd_test_kit/cross_suite/requests_logical_model_validation.rb
@@ -78,7 +78,8 @@ module DaVinciCRDTestKit
     end
 
     def draft_orders_conform_to_profiles?(request_body, request_index, ig_semver)
-      resource = FHIR.from_contents(request_body.dig('context', 'draftOrders')&.to_json)
+      draft_orders = request_body.dig('context', 'draftOrders').to_json
+      resource = FHIR.from_contents(draft_orders)
       resource_is_valid?(resource:, profile_url: "http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-bundle-request|#{ig_semver}",
                          message_prefix: "(Request #{request_index + 1}) context.draftOrders - ")
     end

--- a/spec/davinci_crd_test_kit/client/endpoints/hook_request_endpoint_spec.rb
+++ b/spec/davinci_crd_test_kit/client/endpoints/hook_request_endpoint_spec.rb
@@ -115,6 +115,30 @@ RSpec.describe DaVinciCRDTestKit::HookRequestEndpoint, :request do
         .to match(/Hook instance `#{order_sign_hook_request['hookInstance']}` has already been used in this session./)
     end
 
+    it 'returns 400 with OperationOutcome when the hook field is missing from the request' do
+      allow(test).to receive(:suite).and_return(suite)
+      token = jwt_helper.build(
+        aud: order_sign_url,
+        iss: example_client_url,
+        jku: "#{example_client_url}/jwks.json",
+        encryption_method: 'RS384'
+      )
+
+      run(test, cds_jwt_iss: example_client_url,
+                order_sign_response_approach: 'custom',
+                order_sign_custom_response_template: instructions_card_template.to_json)
+
+      order_sign_hook_request.delete('hook')
+      header('Authorization', "Bearer #{token}")
+      post_json(server_endpoint, order_sign_hook_request)
+
+      expect(last_response.status).to eq(400)
+      parsed_body = JSON.parse(last_response.body)
+      expect(parsed_body['resourceType']).to eq('OperationOutcome')
+      expect(parsed_body['issue'].first['details']['text'])
+        .to match(/No hook requested/)
+    end
+
     it 'returns 400 with OperationOutcome when the requested hook does not match the invoked hook' do
       allow(test).to receive(:suite).and_return(suite)
       token = jwt_helper.build(

--- a/spec/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker_spec.rb
+++ b/spec/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker_spec.rb
@@ -305,6 +305,26 @@ RSpec.describe DaVinciCRDTestKit::PrefetchCompletenessChecker do
         .to eq(['(Request 1) Prefetch Template coverage - prefetched Coverage has an unexpected ' \
                 'beneficiary reference: expected Patient/example, got Patient/wrong.'])
     end
+
+    it 'returns an error when the coverage Bundle has no entry element' do
+      order_sign_request['prefetch'] = { 'coverage' => { 'resourceType' => 'Bundle' } }
+      expect(errors_for(order_sign_request, templates))
+        .to eq(['(Request 1) Prefetch Template coverage - exactly one Coverage must be provided.'])
+    end
+
+    it 'returns a resourceType error when the prefetched value is a Coverage resource' do
+      order_sign_request['prefetch'] = { 'coverage' => crd_coverage_example }
+      expect(errors_for(order_sign_request, templates))
+        .to eq(['(Request 1) Prefetch Template coverage - prefetched value has unexpected resourceType: ' \
+                'expected Bundle, got Coverage.'])
+    end
+
+    it 'returns a resourceType error when the prefetched value is a Patient resource' do
+      order_sign_request['prefetch'] = { 'coverage' => crd_patient_example }
+      expect(errors_for(order_sign_request, templates))
+        .to eq(['(Request 1) Prefetch Template coverage - prefetched value has unexpected resourceType: ' \
+                'expected Bundle, got Patient.'])
+    end
   end
 
   describe 'unsupported search template' do

--- a/spec/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker_spec.rb
+++ b/spec/davinci_crd_test_kit/cross_suite/prefetch_completeness_checker_spec.rb
@@ -303,7 +303,8 @@ RSpec.describe DaVinciCRDTestKit::PrefetchCompletenessChecker do
       order_sign_request['prefetch'] = { 'coverage' => crd_coverage_example_bundle }
       expect(errors_for(order_sign_request, templates))
         .to eq(['(Request 1) Prefetch Template coverage - prefetched Coverage has an unexpected ' \
-                'beneficiary reference: expected Patient/example, got Patient/wrong.'])
+                'beneficiary reference: expected Patient/example or https://example/r4/Patient/example, ' \
+                'got Patient/wrong.'])
     end
 
     it 'returns an error when the coverage Bundle has no entry element' do

--- a/spec/davinci_crd_test_kit/cross_suite/requests_logical_model_validation_spec.rb
+++ b/spec/davinci_crd_test_kit/cross_suite/requests_logical_model_validation_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe DaVinciCRDTestKit::RequestsLogicalModelValidation do
       it 'does not raise an error when draftOrders is absent' do
         order_sign_request['context'].delete('draftOrders')
         expect { module_instance.send(:check_context_resource_profiles, order_sign_request, 0, '2.2.1') }
-          .not_to raise_error
+          .to_not raise_error
       end
     end
 

--- a/spec/davinci_crd_test_kit/cross_suite/requests_logical_model_validation_spec.rb
+++ b/spec/davinci_crd_test_kit/cross_suite/requests_logical_model_validation_spec.rb
@@ -322,6 +322,12 @@ RSpec.describe DaVinciCRDTestKit::RequestsLogicalModelValidation do
         expect(call[:profile_url]).to include('2.2.1')
         expect(call[:message_prefix]).to include('context.draftOrders')
       end
+
+      it 'does not raise an error when draftOrders is absent' do
+        order_sign_request['context'].delete('draftOrders')
+        expect { module_instance.send(:check_context_resource_profiles, order_sign_request, 0, '2.2.1') }
+          .not_to raise_error
+      end
     end
 
     context 'when the hook is order-select' do


### PR DESCRIPTION
# Summary

Fixes several bugs identified by a tester and their sample input, including:
- Previously, Inferno returned a 500 error without much detail when hook requests did not include the `hook` property. Now, Inferno returns a 400 error indicating that the `hook` property is missing.
- Previously, when the `draftOrders` context element was not present on order-sign and order-select hooks, Inferno's request conformance check bombed. Now, Inferno handles the omission appropriately, including indicating that the field is required.
- Previously, Inferno's check of prefetch data bombed when the `coverage` prefetch key contained something other than a Bundle. Now, Inferno handles that case appropriately, including verification of a raw Coverage resource that includes an error indicating that it needs to be in a Bundle.
- Previously, Inferno's check for the Coverage beneficiary required a relative reference. Now, the reference can be absolute.

# Testing Guidance

## Error Cases

To verify in the UI, follow these instructions:
1. Start a local instance of the CRD Test Kit and create a Client v2.2.1 session.
2. Run Group 1.1 Registration with **CRD JWT Issuer** "fhirR239" and attest that configuration is complete when asked.
3. Run Group 1.2.6 order-sign with the default inputs.
4. When waiting, use postman or another tool to submit the request below to `http://localhost:4567/custom/crd_client_v221/cds-services/order-sign-service`
5. Confirm that a 400 is returned with an OperationOutcome indicating the `hook` element is missing.
6. Resend the request with `"hook": "order-sign"` and confirm that a proper CRD response is returned.
7. Indicate all requests have been sent and attest to the display when asked (may take some time if the validator is not yet warmed up).
8. Confirm the following errors:
  - 1.2.6.3.01 Hook requests have the correct structure and contents - includes an error indicating that draftOrders is required but not present.
  -  1.2.6.3.04 Hook requests include the requested prefetch data - includes an error indicating the the coverage prefetch must be a Bundle, not a Coverage and that the beneficiary reference is not correct (absolute reference but without a fhirServer.

```
{
    "context" : 
	{
		"encounterId" : "Encounter/123",
		"patientId" : "Patient/e234ec13-05f2-4cea-ae71-f336c2a52b9a",
		"userId" : "Practitioner/e234ec13-05f2-4cea-ae71-f336c2a52b9a"
	},
	"fhirAuthorization" : 
	{
		"access_token" : "asdf",
		"expires_in" : 300,
		"scope" : "user/Patient.read user/Observation.read",
		"subject" : "cds-service4",
		"token_type" : "Bearer"
	},
	"hookInstance" : "xLAa3BtaRFKVoFGsVTQdLg",
	"prefetch" : 
	{
		"coverage" : 
		{
			"beneficiary" : 
			{
				"display" : "Tilly FHIRTest",
				"reference" : "https://fhirtest.medenttest.com/fhir/R4/fhirR239/Patient/e234ec13-05f2-4cea-ae71-f336c2a52b9a"
			},
			"class" : 
			[
				{
					"name" : "MEDICARE PA",
					"type" : 
					{
						"coding" : 
						[
							{
								"code" : "plan",
								"system" : "http://terminology.hl7.org/CodeSystem/coverage-class"
							}
						]
					},
					"value" : "MEDICARE PA"
				}
			],
			"id" : "13dc2198-70ca-4f91-85d8-16a8cf2023d0",
			"identifier" : 
			[
				{
					"system" : "urn::oid::2.16.840.1.113883.3.227",
					"use" : "usual",
					"value" : "13dc2198-70ca-4f91-85d8-16a8cf2023d0"
				},
				{
					"type" : 
					{
						"coding" : 
						[
							{
								"code" : "MB",
								"display" : "Member Number",
								"system" : "http://terminology.hl7.org/CodeSystem/v2-0203"
							}
						]
					},
					"value" : "4444"
				}
			],
			"payor" : 
			[
				{
					"display" : "MEDICARE PA",
					"reference" : "Organization/12502.payor"
				}
			],
			"period" : 
			{
				"start" : "2025-06-01"
			},
			"relationship" : 
			{
				"coding" : 
				[
					{
						"code" : "self",
						"system" : "http://terminology.hl7.org/CodeSystem/subscriber-relationship"
					}
				]
			},
			"resourceType" : "Coverage",
			"status" : "active",
			"subscriberId" : "4444",
			"type" : 
			{
				"coding" : 
				[
					{
						"code" : "71",
						"display" : "HMO",
						"system" : "https://nahdo.org/sopt"
					}
				]
			}
		},
		"patient" : 
		{
			"active" : true,
			"address" : 
			[
				{
					"city" : "AUBURN",
					"country" : "US",
					"line" : 
					[
						"123 Main Lane"
					],
					"period" : 
					{
						"end" : "2025-09-09",
						"start" : "2019-07-08"
					},
					"postalCode" : "13021",
					"state" : "NY",
					"type" : "postal",
					"use" : "home"
				},
				{
					"city" : "Auburn",
					"country" : "US",
					"line" : 
					[
						"123 Main Lane"
					],
					"period" : 
					{
						"end" : "2008-03-05",
						"start" : "2005-05-07"
					},
					"postalCode" : "13021",
					"state" : "NY",
					"type" : "postal",
					"use" : "old"
				}
			],
			"birthDate" : "1990-04-03",
			"communication" : 
			[
				{
					"language" : 
					{
						"coding" : 
						[
							{
								"code" : "en",
								"display" : "English",
								"system" : "urn:ietf:bcp:47"
							}
						],
						"text" : "English"
					},
					"preferred" : true
				}
			],
			"deceasedBoolean" : false,
			"extension" : 
			[
				{
					"extension" : 
					[
						{
							"url" : "text",
							"valueString" : "White"
						},
						{
							"url" : "ombCategory",
							"valueCoding" : 
							{
								"code" : "2106-3",
								"display" : "White",
								"system" : "urn:oid:2.16.840.1.113883.6.238"
							}
						}
					],
					"url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
				},
				{
					"url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",
					"valueCode" : "248152002"
				},
				{
					"extension" : 
					[
						{
							"url" : "text",
							"valueString" : "Not Hispanic or Latino"
						},
						{
							"url" : "ombCategory",
							"valueCoding" : 
							{
								"code" : "2186-5",
								"display" : "Not Hispanic or Latino",
								"system" : "urn:oid:2.16.840.1.113883.6.238"
							}
						}
					],
					"url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
				},
				{
					"url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity",
					"valueCodeableConcept" : 
					{
						"coding" : 
						[
							{
								"code" : "NASK",
								"display" : "Not Asked",
								"system" : "http://terminology.hl7.org/6.0.2/CodeSystem-v3-NullFlavor.html"
							}
						]
					}
				},
				{
					"extension" : 
					[
						{
							"url" : "tribalAffiliation",
							"valueCodeableConcept" : 
							{
								"coding" : 
								[
									{
										"code" : "348",
										"display" : "Allakaket Village",
										"system" : "http://terminology.hl7.org/CodeSystem/v3-TribalEntityUS"
									}
								]
							}
						},
						{
							"url" : "isEnrolled",
							"valueBoolean" : true
						},
						{
							"url" : "tribalAffiliation",
							"valueCodeableConcept" : 
							{
								"coding" : 
								[
									{
										"code" : "495",
										"display" : "Oscarville Traditional Village",
										"system" : "http://terminology.hl7.org/CodeSystem/v3-TribalEntityUS"
									}
								]
							}
						},
						{
							"url" : "isEnrolled",
							"valueBoolean" : true
						}
					],
					"url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation"
				},
				{
					"url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
					"valueCode" : "UNK"
				}
			],
			"gender" : "female",
			"id" : "e234ec13-05f2-4cea-ae71-f336c2a52b9a",
			"identifier" : 
			[
				{
					"system" : "urn::oid::2.16.840.1.113883.3.227",
					"use" : "official",
					"value" : "e234ec13-05f2-4cea-ae71-f336c2a52b9a"
				},
				{
					"system" : "urn::oid::2.16.840.1.113883.3.227",
					"use" : "usual",
					"value" : "MRN.1918.00ea2ede-8605-4d9b-a055-1e5c3a1aea87"
				},
				{
					"system" : "urn::oid::2.16.840.1.113883.3.227",
					"use" : "secondary",
					"value" : "1253"
				}
			],
			"managingOrganization" : 
			{
				"display" : "medent Practice fhirR239",
				"reference" : "https://fhirtest.medenttest.com/fhir/R4/fhirR239/Organization/fhirR239.practiceid"
			},
			"name" : 
			[
				{
					"family" : "FHIRTest",
					"given" : 
					[
						"Tilly"
					],
					"use" : "usual"
				},
				{
					"family" : "turtle",
					"given" : 
					[
						"baby"
					],
					"period" : 
					{
						"end" : "2021-01-01",
						"start" : "2020-01-01"
					},
					"use" : "old"
				}
			],
			"resourceType" : "Patient",
			"telecom" : 
			[
				{
					"system" : "phone",
					"use" : "home",
					"value" : "(315)-255-0900"
				},
				{
					"system" : "phone",
					"use" : "work",
					"value" : "(   )-   -"
				},
				{
					"system" : "phone",
					"use" : "mobile",
					"value" : "(315)-255-0900"
				},
				{
					"system" : "email",
					"use" : "home",
					"value" : "margoth@medent.com"
				}
			]
		}
	}
}
```

## Fixed beneficiary reference

Confirm that the beneficiary reference can be absolute as long as the `fhirServer` is indicated.  Run the same procedure as above, but without the submission without the `hook` and also add `"fhirServer": "https://fhirtest.medenttest.com/fhir/R4/fhirR239",`. In step 8. the beneficiary reference error on test "1.2.6.3.04 Hook requests include the requested prefetch data" will no longer be present.


